### PR TITLE
TIMX 424 - reorder partition columns

### DIFF
--- a/tests/test_dataset_write.py
+++ b/tests/test_dataset_write.py
@@ -169,14 +169,14 @@ def test_dataset_write_schema_partitions_correctly_ordered(
             "source": "alma",
             "run_date": "2024-12-01",
             "run_type": "daily",
-            "action": "index",
             "run_id": "000-111-aaa-bbb",
+            "action": "index",
         },
     )
     file = written_files[0]
     assert (
         "/source=alma/run_date=2024-12-01/run_type=daily"
-        "/action=index/run_id=000-111-aaa-bbb" in file.path
+        "/run_id=000-111-aaa-bbb/action=index/" in file.path
     )
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,18 +43,17 @@ def generate_sample_records_with_simulated_partitions(
     run_dates = ["2024-01-01", "2024-06-15", "2024-12-31"]
     run_types = ["full", "daily"]
     actions = ["index", "delete"]
-    run_ids = [str(uuid.uuid4()) for x in range(num_run_ids)]
 
     records_remaining = num_records
     while records_remaining > 0:
         batch_size = random.randint(1, min(100, records_remaining))
+        source = random.choice(sources)
         yield from generate_sample_records(
             num_records=batch_size,
-            timdex_record_id_prefix=random.choice(sources),
-            source=random.choice(sources),
+            timdex_record_id_prefix=source,
+            source=source,
             run_date=random.choice(run_dates),
             run_type=random.choice(run_types),
             action=random.choice(actions),
-            run_id=random.choice(run_ids),
         )
         records_remaining -= batch_size

--- a/timdex_dataset_api/__init__.py
+++ b/timdex_dataset_api/__init__.py
@@ -3,7 +3,7 @@
 from timdex_dataset_api.dataset import TIMDEXDataset
 from timdex_dataset_api.record import DatasetRecord
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     "DatasetRecord",

--- a/timdex_dataset_api/dataset.py
+++ b/timdex_dataset_api/dataset.py
@@ -28,8 +28,8 @@ TIMDEX_DATASET_SCHEMA = pa.schema(
         pa.field("source", pa.string()),
         pa.field("run_date", pa.date32()),
         pa.field("run_type", pa.string()),
-        pa.field("action", pa.string()),
         pa.field("run_id", pa.string()),
+        pa.field("action", pa.string()),
     )
 )
 
@@ -37,8 +37,8 @@ TIMDEX_DATASET_PARTITION_COLUMNS = [
     "source",
     "run_date",
     "run_type",
-    "action",
     "run_id",
+    "action",
 ]
 
 DEFAULT_BATCH_SIZE = 1_000

--- a/timdex_dataset_api/record.py
+++ b/timdex_dataset_api/record.py
@@ -24,8 +24,8 @@ class DatasetRecord:
     source: str | None = None
     run_date: str | datetime.datetime | None = None
     run_type: str | None = None
-    action: str | None = None
     run_id: str | None = None
+    action: str | None = None
 
     def to_dict(
         self,
@@ -46,7 +46,7 @@ class DatasetRecord:
         # ensure all partition columns are set
         missing_partition_values = [
             field
-            for field in ["source", "run_date", "run_type", "action", "run_id"]
+            for field in ["source", "run_date", "run_type", "run_id", "action"]
             if getattr(self, field) is None
         ]
         if missing_partition_values:


### PR DESCRIPTION
### Purpose and background context

The primary purpose of this PR is to move the `run_id` partition before the `action` partition.  Also included are (inconsequential) updates to testing utilities and some updates to logging after write.

Firstly, this re-ordering [matches the original ordering proposed in the engineering plan](https://mitlibraries.atlassian.net/wiki/spaces/IN/pages/4094296066/Engineering+Plan+Parquet+Datasets+for+TIMDEX+ETL#Row-Schema) for partitions.  Unsure how/why these changed order along the way, but basically reverting to the original proposal.

Second, a more recent discussion surfaced why this ordering makes sense, [outlined here as a development note in the engineering plan](https://mitlibraries.atlassian.net/wiki/spaces/IN/pages/4094296066/Engineering+Plan+Parquet+Datasets+for+TIMDEX+ETL#Use-dataset-location-prefixed-with-partition-values-for-efficient-subset-access).  In short: where possible, we'll want to avoid loading the entire dataset from the root of the dataset.  As the number of parquet files and partitions grow in S3, it will increase the load time to scan files and read their metadata.

Virtually always in a TIMDEX run context we'll be interested in _only_ the files for the current run.  And for that run, we'll know the partitions: `[source, run_date, run_type, run_id]`.  We will _not_ know `action`, as Transmogrifier somewhat dynamically sets this for each record.

Given the partition values we know, and the ability of `pyarrow.dataset` to load a prefix -- confirmed works for local and S3 locations -- we can load only a subset of the full dataset.  The _effect_ is similar to loading the full thing, then filtering based on partitions, but we're short-circuiting the part where lots of files are touched just to be filtered out.

With `run_id` before `action, we can load a dataset like this nearly instantly, confident it will contain all records for the run:

```
from pyarrow.dataset import ds
dataset = ds.dataset("s3://timdex-bucket/dataset/source=alma/run-date=2024-12-01/run-type=full/run-id=abc123")
```

[TIMX-425](https://mitlibraries.atlassian.net/browse/TIMX-425) is focused on the ergonomics of this, where the `TIMDEXDataset.load()` will allow passing of partition values, but under the hood will apply this prefix approach.  All of this hinges on `run_id` being "above" or "before" the `action` partition.

### How can a reviewer manually see the effects of these changes?

1- start ipython shell
```shell
pipenv run ipython
```

2- create a small dataset
```python
from tests.utils import generate_sample_records_with_simulated_partitions
from timdex_dataset_api import TIMDEXDataset

td = TIMDEXDataset(location="/tmp/test-dataset-ordering")
sample_records = generate_sample_records_with_simulated_partitions(5_000)
written_files = td.write(sample_records)
```

Releated to logging update, note the logged statistics from the run:
```
Dataset write complete - elapsed: 0.05s, total files: 99, total rows: 5000, total size: 159248
```

3- Observe the filename of the parquet file created, how `run_id=XXX` is before `action=index`
```python
written_files[0].path
# Out[3]: '/tmp/test-dataset/source=alma/run_date=2024-01-01/run_type=full/run_id=7dc872e8-634b-4804-8580-083a586508d0/action=index/2e99bf8b-f827-45dd-8439-a778425546a8-0.parquet'
```


### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-424

### Developer
- [X] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes



[TIMX-425]: https://mitlibraries.atlassian.net/browse/TIMX-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ