### PR TITLE
TIMX 417 - read from dataset

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,23 @@ def fixed_local_dataset(tmp_path) -> TIMDEXDataset:
     method.
     """
     timdex_dataset = TIMDEXDataset(str(tmp_path / "fixed_local_dataset/"))
-    timdex_dataset.write(generate_sample_records(num_records=5_000, run_id="abc123"))
+    for source, run_id in [
+        ("alma", "abc123"),
+        ("dspace", "def456"),
+        ("aspace", "ghi789"),
+        ("libguides", "jkl123"),
+        ("gismit", "mno456"),
+    ]:
+        timdex_dataset.write(
+            generate_sample_records(
+                num_records=1_000,
+                timdex_record_id_prefix=source,
+                source=source,
+                run_date="2024-12-01",
+                run_id=run_id,
+            )
+        )
+    timdex_dataset.load()
     return timdex_dataset
 
 

--- a/tests/test_dataset_read.py
+++ b/tests/test_dataset_read.py
@@ -1,0 +1,91 @@
+# ruff: noqa: PLR2004, PD901
+
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+DATASET_COLUMNS_SET = {
+    "timdex_record_id",
+    "source_record",
+    "transformed_record",
+    "source",
+    "run_date",
+    "run_type",
+    "run_id",
+    "action",
+    "year",
+    "month",
+    "day",
+}
+
+
+def test_read_batches_yields_pyarrow_record_batches(fixed_local_dataset):
+    batches = fixed_local_dataset.read_batches_iter()
+    batch = next(batches)
+    assert isinstance(batch, pa.RecordBatch)
+
+
+def test_read_batches_all_columns_by_default(fixed_local_dataset):
+    batches = fixed_local_dataset.read_batches_iter()
+    batch = next(batches)
+    assert set(batch.column_names) == DATASET_COLUMNS_SET
+
+
+def test_read_batches_filter_columns(fixed_local_dataset):
+    columns_subset = ["source", "transformed_record"]
+    batches = fixed_local_dataset.read_batches_iter(columns=columns_subset)
+    batch = next(batches)
+    assert set(batch.column_names) == set(columns_subset)
+
+
+def test_read_batches_no_filters_gets_full_dataset(fixed_local_dataset):
+    batches = fixed_local_dataset.read_batches_iter()
+    table = pa.Table.from_batches(batches)
+    assert len(table) == fixed_local_dataset.row_count
+
+
+def test_read_batches_with_filters_gets_subset_of_dataset(fixed_local_dataset):
+    batches = fixed_local_dataset.read_batches_iter(
+        source="libguides",
+        run_date="2024-12-01",
+        run_type="daily",
+        action="index",
+    )
+
+    table = pa.Table.from_batches(batches)
+    assert len(table) == 1_000
+    assert len(table) < fixed_local_dataset.row_count
+
+    # assert loaded dataset is unchanged by filtering for a read method
+    assert fixed_local_dataset.row_count == 5_000
+
+
+def test_read_dataframe_batches_yields_dataframes(fixed_local_dataset):
+    df_iter = fixed_local_dataset.read_dataframes_iter()
+    df_batch = next(df_iter)
+    assert isinstance(df_batch, pd.DataFrame)
+    assert len(df_batch) == 1_000
+
+
+def test_read_dataframe_reads_all_dataset_rows_after_filtering(fixed_local_dataset):
+    df = fixed_local_dataset.read_dataframe()
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == fixed_local_dataset.row_count
+
+
+def test_read_dicts_yields_dictionary_for_each_dataset_record(fixed_local_dataset):
+    records = fixed_local_dataset.read_dicts_iter()
+    record = next(records)
+    assert isinstance(record, dict)
+    assert set(record.keys()) == DATASET_COLUMNS_SET
+
+
+def test_read_batches_filter_to_none_returns_empty_list(fixed_local_dataset):
+    batches = fixed_local_dataset.read_batches_iter(source="not-gonna-find-me")
+    assert list(batches) == []
+
+
+def test_read_dicts_filter_to_none_stopiteration_immediately(fixed_local_dataset):
+    batches = fixed_local_dataset.read_dicts_iter(source="not-gonna-find-me")
+    with pytest.raises(StopIteration):
+        next(batches)

--- a/timdex_dataset_api/__init__.py
+++ b/timdex_dataset_api/__init__.py
@@ -3,7 +3,7 @@
 from timdex_dataset_api.dataset import TIMDEXDataset
 from timdex_dataset_api.record import DatasetRecord
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 __all__ = [
     "DatasetRecord",


### PR DESCRIPTION
### Purpose and background context

This PR adds the ability to read from a TIMDEX dataset.

Applications like the TIMDEX pipeline lambdas or TIM will need to read records from the dataset to perform further actions.  This PR introduces some baseline methods on the `TIMDEXDataset` class to allow for quickly and efficiently reading records from a dataset.

This PR also introduces some refactoring of dataset filtering (commit https://github.com/MITLibraries/timdex-dataset-api/pull/52/commits/725125800d5ec141e493c648fcd765d0024adf4f) to accomodate 4-5 new read methods that all _also_ support datasaet filtering.  The approach was to follow python [PEP 692](https://peps.python.org/pep-0692/) which introduced typed `kwargs` for a function.  In this way, we are able to create a single typed dictionary of kwargs we might expect for a function (i.e. dataset filters).

### How can a reviewer manually see the effects of these changes?

1- Set Dev1 `TIMDEXManagers` credentials

2- Start ipython shell
```shell
pipenv run ipython
```

3- Load a dataset _without_ any filtering
```python
from timdex_dataset_api import TIMDEXDataset
td = TIMDEXDataset(location="s3://timdex-extract-dev-222053980223/dataset/")
td.load()
```

4- Filter by a `run_id` and load entire run as pandas dataframe
```python
run_df = td.read_dataframe(run_id="fe6e9d6d-67f7-4250-8842-4e43ebd53c02")

# observe dataframe is 360 rows all for the same run
display(run_df)
"""
             timdex_record_id                                      source_record                                 transformed_record     source    run_date run_type                                run_id action  year month day
0     libguides:guides-175846  b'<?xml version="1.0" encoding="utf-8"?>\n<rec...  b'{"source": "LibGuides", "source_link": "http...  libguides  2024-12-18     full  fe6e9d6d-67f7-4250-8842-4e43ebd53c02  index  2024    12  18
1     libguides:guides-175847  b'<?xml version="1.0" encoding="utf-8"?>\n<rec...  b'{"source": "LibGuides", "source_link": "http...  libguides  2024-12-18     full  fe6e9d6d-67f7-4250-8842-4e43ebd53c02  index  2024    12  18
2     libguides:guides-175849  b'<?xml version="1.0" encoding="utf-8"?>\n<rec...  b'{"source": "LibGuides", "source_link": "http...  libguides  2024-12-18     full  fe6e9d6d-67f7-4250-8842-4e43ebd53c02  index  2024    12  18
3     libguides:guides-175853  b'<?xml version="1.0" encoding="utf-8"?>\n<rec...  b'{"source": "LibGuides", "source_link": "http...  libguides  2024-12-18     full  fe6e9d6d-67f7-4250-8842-4e43ebd53c02  index  2024    12  18
4     libguides:guides-175855  b'<?xml version="1.0" encoding="utf-8"?>\n<rec...  b'{"source": "LibGuides", "source_link": "http...  libguides  2024-12-18     full  fe6e9d6d-67f7-4250-8842-4e43ebd53c02  index  2024    12  18
..                        ...                                                ...                                                ...        ...         ...      ...                                   ...    ...   ...   ...  ..
355  libguides:guides-1402904  b'<?xml version="1.0" encoding="utf-8"?>\n<rec...  b'{"source": "LibGuides", "source_link": "http...  libguides  2024-12-18     full  fe6e9d6d-67f7-4250-8842-4e43ebd53c02  index  2024    12  18
356  libguides:guides-1415734  b'<?xml version="1.0" encoding="utf-8"?>\n<rec...  b'{"source": "LibGuides", "source_link": "http...  libguides  2024-12-18     full  fe6e9d6d-67f7-4250-8842-4e43ebd53c02  index  2024    12  18
357  libguides:guides-1429216  b'<?xml version="1.0" encoding="utf-8"?>\n<rec...  b'{"source": "LibGuides", "source_link": "http...  libguides  2024-12-18     full  fe6e9d6d-67f7-4250-8842-4e43ebd53c02  index  2024    12  18
358  libguides:guides-1434814  b'<?xml version="1.0" encoding="utf-8"?>\n<rec...  b'{"source": "LibGuides", "source_link": "http...  libguides  2024-12-18     full  fe6e9d6d-67f7-4250-8842-4e43ebd53c02  index  2024    12  18
359  libguides:guides-1435500  b'<?xml version="1.0" encoding="utf-8"?>\n<rec...  b'{"source": "LibGuides", "source_link": "http...  libguides  2024-12-18     full  fe6e9d6d-67f7-4250-8842-4e43ebd53c02  index  2024    12  18

[360 rows x 11 columns]
"""
```

5- Retrieve a single record as a dictionary, similar to what TIM might require
```python
record = next(td.read_dicts_iter(run_id="fe6e9d6d-67f7-4250-8842-4e43ebd53c02"))

display(record)
"""
{'timdex_record_id': 'libguides:guides-175846',
 'source_record': b'<?xml version="1.0" encoding="utf-8"?>\n<record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><header><identifier>oai:libguides.com:guides/175846</identifier><datestamp>2024-07-09T17:17:40Z</datestamp><setSpec>guides</setSpec></header><metadata><oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd"><dc:title>Materials Science &amp; Engineering</dc:title><dc:creator>Tina Chan</dc:creator><dc:subject>Engineering</dc:subject><dc:subject>Science</dc:subject><dc:description>Useful databases and other research tips for materials science.</dc:description><dc:publisher>MIT Libraries</dc:publisher><dc:date>2008-06-19 17:55:27</dc:date><dc:identifier>https://libguides.mit.edu/materials</dc:identifier></oai_dc:dc></metadata></record>',
 'transformed_record': b'{"source": "LibGuides", "source_link": "https://libguides.mit.edu/materials", "timdex_record_id": "libguides:guides-175846", "title": "Materials Science & Engineering", "citation": "Tina Chan. Materials Science & Engineering. MIT Libraries. libguides. https://libguides.mit.edu/materials", "content_type": ["libguides"], "contributors": [{"value": "Tina Chan", "kind": "Creator"}], "dates": [{"kind": "Created", "value": "2008-06-19T17:55:27"}], "format": "electronic resource", "identifiers": [{"value": "oai:libguides.com:guides/175846", "kind": "OAI-PMH"}], "links": [{"url": "https://libguides.mit.edu/materials", "kind": "LibGuide URL", "text": "LibGuide URL"}], "publishers": [{"name": "MIT Libraries"}], "subjects": [{"value": ["Engineering", "Science"], "kind": "Subject scheme not provided"}], "summary": ["Useful databases and other research tips for materials science."]}',
 'source': 'libguides',
 'run_date': datetime.date(2024, 12, 18),
 'run_type': 'full',
 'run_id': 'fe6e9d6d-67f7-4250-8842-4e43ebd53c02',
 'action': 'index',
 'year': '2024',
 'month': '12',
 'day': '18'}
"""
```

For a bit more advanced usage, here is an example of subsetting what columns are returned for some analysis, and then some batch reading.  This pulls from a simulated dataset in Dev1, `s3://timdex-extract-dev-222053980223/dataset-five-year-simulation/`, that has lots of records.

```python
from timdex_dataset_api import TIMDEXDataset
td = TIMDEXDataset(location="s3://timdex-extract-dev-222053980223/dataset-five-year-simulation/")

# filter to a single day on load; utilizes partitions and quite quick
td.load(run_date='2026-06-15')

# get run_ids from this day
td.read_dataframe(columns=['source','run_id']).value_counts()
"""
Out[23]: 
source             run_id                              
alma               8efa0222-0889-4f16-aeb3-3ca60db89260    30332
gisogm             f3834404-348c-4a76-9154-def53233a1c4     5245
dspace             9cabbbe8-922f-4758-b680-707d8b802cc9      184
aspace             df2daf00-1381-4755-80ba-2964422333e7       33
libguides          272cc8fc-87af-4f9c-b6ed-6132e8a2cb8a        9
researchdatabases  f82c7458-37a8-425d-8f0a-8af03ba193c3        7
gismit             bf891864-8c66-4441-ab18-b2bb0281aeba        2
Name: count, dtype: int64
"""

# get record batches as lists of dictionaries, similar to what TIM would bulk insert into Opensearch
for record_batch in td.read_dicts_iter(run_id="8efa0222-0889-4f16-aeb3-3ca60db89260"):
    print("Doing something with batch...")
```

### Includes new or updated dependencies?
YES

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-417

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes