### PR TITLE
Add read method for yielding transformed records to TIMDEXDataset

### DIFF
--- a/tests/test_dataset_read.py
+++ b/tests/test_dataset_read.py
@@ -89,3 +89,10 @@ def test_read_dicts_filter_to_none_stopiteration_immediately(fixed_local_dataset
     batches = fixed_local_dataset.read_dicts_iter(source="not-gonna-find-me")
     with pytest.raises(StopIteration):
         next(batches)
+
+
+def test_read_transformed_records_yields_parsed_dictionary(fixed_local_dataset):
+    batches = fixed_local_dataset.read_transformed_records_iter()
+    transformed_record = next(batches)
+    assert isinstance(transformed_record, dict)
+    assert transformed_record == {"title": ["Hello World."]}

--- a/timdex_dataset_api/dataset.py
+++ b/timdex_dataset_api/dataset.py
@@ -1,6 +1,7 @@
 """timdex_dataset_api/dataset.py"""
 
 import itertools
+import json
 import operator
 import time
 import uuid
@@ -468,3 +469,19 @@ class TIMDEXDataset:
             columns=columns, batch_size=batch_size, **filters
         ):
             yield from record_batch.to_pylist()
+
+    def read_transformed_records_iter(
+        self,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        **filters: Unpack[DatasetFilters],
+    ) -> Iterator[dict]:
+        """Yield individual transformed records as dictionaries from the dataset.
+
+        If 'transformed_record' is None (i.e., action="skip"|"error"), the yield
+        statement will not be executed for the row.
+        """
+        for record_dict in self.read_dicts_iter(
+            columns=["transformed_record"], batch_size=batch_size, **filters
+        ):
+            if transformed_record := record_dict["transformed_record"]:
+                yield json.loads(transformed_record)


### PR DESCRIPTION
### Purpose and background context
Transformed records are recorded as serialized JSON strings under the transformed_record column for each row in a TIMDEXDataset. This new method will resemble the read methods implemented via https://mitlibraries.atlassian.net/browse/TIMX-417 , with the additional step of parsing the JSON string and yielding dictionaries of transformed records. 

### How can a reviewer manually see the effects of these changes?
Reviewing the [new unit test](https://github.com/MITLibraries/timdex-dataset-api/compare/TIMX-453-read-transformed-records-from-dataset?expand=1#diff-b2a37482b2c59ca7f4496a3205006af83b1a741ffef35367941f60a0fdec818cR94-R98) should be sufficient for this PR.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES - These changes came from initial discussions on how TIM accesses transformed records from a `TIMDEXDataset`. Applications like TIM can use this method to retrieve parsed transformed records from the dataset.

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-453

### Developer
- [x] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

