### PR TITLE
TIMX 427 - improve logging

### DIFF
--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -4,19 +4,9 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-DATASET_COLUMNS_SET = {
-    "timdex_record_id",
-    "source_record",
-    "transformed_record",
-    "source",
-    "run_date",
-    "run_type",
-    "run_id",
-    "action",
-    "year",
-    "month",
-    "day",
-}
+from timdex_dataset_api.dataset import TIMDEX_DATASET_SCHEMA
+
+DATASET_COLUMNS_SET = set(TIMDEX_DATASET_SCHEMA.names)
 
 
 def test_read_batches_yields_pyarrow_record_batches(fixed_local_dataset):

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,0 +1,73 @@
+import re
+from datetime import date
+
+import pytest
+
+from timdex_dataset_api.record import DatasetRecord
+
+
+def test_dataset_record_init_with_valid_run_date_parses_year_month_day():
+    values = {
+        "timdex_record_id": "alma:123",
+        "source_record": b"<record><title>Hello World.</title></record>",
+        "transformed_record": b"""{"title":["Hello World."]}""",
+        "source": "libguides",
+        "run_date": "2024-12-01",
+        "run_type": "full",
+        "action": "index",
+        "run_id": "000-111-aaa-bbb",
+    }
+    record = DatasetRecord(**values)
+
+    assert record
+    assert (record.year, record.month, record.day) == (
+        "2024",
+        "12",
+        "01",
+    )
+
+
+def test_dataset_record_init_with_invalid_run_date_raise_error():
+    values = {
+        "timdex_record_id": "alma:123",
+        "source_record": b"<record><title>Hello World.</title></record>",
+        "transformed_record": b"""{"title":["Hello World."]}""",
+        "source": "libguides",
+        "run_date": "-12-01",
+        "run_type": "full",
+        "action": "index",
+        "run_id": "000-111-aaa-bbb",
+    }
+
+    with pytest.raises(
+        ValueError, match=re.escape("time data '-12-01' does not match format '%Y-%m-%d'")
+    ):
+        DatasetRecord(**values)
+
+
+def test_dataset_record_serialization():
+    values = {
+        "timdex_record_id": "alma:123",
+        "source_record": b"<record><title>Hello World.</title></record>",
+        "transformed_record": b"""{"title":["Hello World."]}""",
+        "source": "libguides",
+        "run_date": "2024-12-01",
+        "run_type": "full",
+        "action": "index",
+        "run_id": "abc123",
+    }
+    dataset_record = DatasetRecord(**values)
+
+    assert dataset_record.to_dict() == {
+        "timdex_record_id": "alma:123",
+        "source_record": b"<record><title>Hello World.</title></record>",
+        "transformed_record": b"""{"title":["Hello World."]}""",
+        "source": "libguides",
+        "run_date": date(2024, 12, 1),
+        "run_type": "full",
+        "action": "index",
+        "run_id": "abc123",
+        "year": "2024",
+        "month": "12",
+        "day": "01",
+    }

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,8 +1,6 @@
 # ruff: noqa: S105, S106, SLF001, PLR2004, PD901, D209, D205
 import math
 import os
-import re
-from datetime import date
 from unittest.mock import patch
 
 import pyarrow.dataset as ds
@@ -14,74 +12,6 @@ from timdex_dataset_api.dataset import (
     TIMDEX_DATASET_SCHEMA,
     TIMDEXDataset,
 )
-from timdex_dataset_api.record import DatasetRecord
-
-
-def test_dataset_record_init():
-    values = {
-        "timdex_record_id": "alma:123",
-        "source_record": b"<record><title>Hello World.</title></record>",
-        "transformed_record": b"""{"title":["Hello World."]}""",
-        "source": "libguides",
-        "run_date": "2024-12-01",
-        "run_type": "full",
-        "action": "index",
-        "run_id": "000-111-aaa-bbb",
-    }
-    record = DatasetRecord(**values)
-
-    assert record
-    assert (record.year, record.month, record.day) == (
-        "2024",
-        "12",
-        "01",
-    )
-
-
-def test_dataset_record_init_with_invalid_run_date_raise_error():
-    values = {
-        "timdex_record_id": "alma:123",
-        "source_record": b"<record><title>Hello World.</title></record>",
-        "transformed_record": b"""{"title":["Hello World."]}""",
-        "source": "libguides",
-        "run_date": "-12-01",
-        "run_type": "full",
-        "action": "index",
-        "run_id": "000-111-aaa-bbb",
-    }
-
-    with pytest.raises(
-        ValueError, match=re.escape("time data '-12-01' does not match format '%Y-%m-%d'")
-    ):
-        DatasetRecord(**values)
-
-
-def test_dataset_record_serialization():
-    values = {
-        "timdex_record_id": "alma:123",
-        "source_record": b"<record><title>Hello World.</title></record>",
-        "transformed_record": b"""{"title":["Hello World."]}""",
-        "source": "libguides",
-        "run_date": "2024-12-01",
-        "run_type": "full",
-        "action": "index",
-        "run_id": "abc123",
-    }
-    dataset_record = DatasetRecord(**values)
-
-    assert dataset_record.to_dict() == {
-        "timdex_record_id": "alma:123",
-        "source_record": b"<record><title>Hello World.</title></record>",
-        "transformed_record": b"""{"title":["Hello World."]}""",
-        "source": "libguides",
-        "run_date": date(2024, 12, 1),
-        "run_type": "full",
-        "action": "index",
-        "run_id": "abc123",
-        "year": "2024",
-        "month": "12",
-        "day": "01",
-    }
 
 
 def test_dataset_write_records_to_new_local_dataset(

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -45,7 +45,7 @@ def test_dataset_write_record_batches_uses_batch_size(
     total_records = 101
     batch_size = 50
     batches = list(
-        new_local_dataset.get_dataset_record_batches(
+        new_local_dataset.create_record_batches(
             sample_records_iter(total_records), batch_size=batch_size
         )
     )

--- a/timdex_dataset_api/__init__.py
+++ b/timdex_dataset_api/__init__.py
@@ -3,7 +3,7 @@
 from timdex_dataset_api.dataset import TIMDEXDataset
 from timdex_dataset_api.record import DatasetRecord
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 __all__ = [
     "DatasetRecord",

--- a/timdex_dataset_api/config.py
+++ b/timdex_dataset_api/config.py
@@ -3,29 +3,22 @@ import os
 
 
 def configure_logger(name: str) -> logging.Logger:
-    """Prepares and returns a logger instance for a given module name.
+    """Prepares a logger instance.
 
-    This approach is suitable for an installed and imported library such as this, where
-    any calling application logging levels and handlers should be utilized.
+    If the env var TDA_LOG_LEVEL is set, the logging level will override the logging
+    level of the calling context.
 
     Args:
         name (str): The name of the logger, typically __name__ is passed by caller
     """
     logger = logging.getLogger(name)
-    logger.addHandler(logging.NullHandler())
 
-    log_level = os.getenv("TDA_LOG_LEVEL", "INFO").strip().upper()
-    if log_level not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
-        raise ValueError(f"Invalid log level: '{log_level}'")
-    logger.setLevel(getattr(logging, log_level))
-
-    handler = logging.StreamHandler()
-    handler.setFormatter(
-        logging.Formatter(
-            "%(asctime)s %(levelname)s %(name)s.%(funcName)s() "
-            "line %(lineno)d: %(message)s"
-        )
-    )
-    logger.addHandler(handler)
+    # set logger level if env var 'TDA_LOG_LEVEL' is set
+    log_level = os.getenv("TDA_LOG_LEVEL")
+    if log_level:
+        log_level = log_level.strip().upper()
+        if log_level not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
+            raise ValueError(f"Invalid log level: '{log_level}'")
+        logger.setLevel(getattr(logging, log_level))
 
     return logger

--- a/timdex_dataset_api/config.py
+++ b/timdex_dataset_api/config.py
@@ -14,10 +14,9 @@ def configure_logger(name: str) -> logging.Logger:
     logger = logging.getLogger(name)
 
     # set logger level if env var 'TDA_LOG_LEVEL' is set
-    log_level = os.getenv("TDA_LOG_LEVEL")
-    if log_level:
+    if log_level := os.getenv("TDA_LOG_LEVEL"):
         log_level = log_level.strip().upper()
-        if log_level not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
+        if log_level not in logging.getLevelNamesMapping():
             raise ValueError(f"Invalid log level: '{log_level}'")
         logger.setLevel(getattr(logging, log_level))
 

--- a/timdex_dataset_api/dataset.py
+++ b/timdex_dataset_api/dataset.py
@@ -363,8 +363,7 @@ class TIMDEXDataset:
             batch = pa.RecordBatch.from_pylist(
                 [record.to_dict() for record in record_batch]
             )
-            message = f"Yielding batch {i+1} for dataset writing."
-            logger.debug(message)
+            logger.debug(f"Yielding batch {i+1} for dataset writing.")
             yield batch
 
     def log_write_statistics(self, start_time: float) -> None:

--- a/timdex_dataset_api/dataset.py
+++ b/timdex_dataset_api/dataset.py
@@ -316,7 +316,7 @@ class TIMDEXDataset:
                 "Dataset location must be the root of a single dataset for writing"
             )
 
-        record_batches_iter = self.get_dataset_record_batches(
+        record_batches_iter = self.create_record_batches(
             records_iter,
             batch_size=batch_size,
         )
@@ -341,7 +341,7 @@ class TIMDEXDataset:
         self.log_write_statistics(start_time)
         return self._written_files  # type: ignore[return-value]
 
-    def get_dataset_record_batches(
+    def create_record_batches(
         self,
         records_iter: Iterator["DatasetRecord"],
         *,
@@ -360,14 +360,11 @@ class TIMDEXDataset:
                 group size in final parquet files
         """
         for i, record_batch in enumerate(itertools.batched(records_iter, batch_size)):
-            batch_start_time = time.perf_counter()
             batch = pa.RecordBatch.from_pylist(
                 [record.to_dict() for record in record_batch]
             )
-            logger.debug(
-                f"Batch {i + 1} yielded for writing, "
-                f"elapsed: {round(time.perf_counter()-batch_start_time, 6)}s"
-            )
+            message = f"Yielding batch {i+1} for dataset writing."
+            logger.debug(message)
             yield batch
 
     def log_write_statistics(self, start_time: float) -> None:


### PR DESCRIPTION
### Purpose and background context

This PR addresses some awkwardness in logging setup.

There are two scenarios with conflicting behavior.  Transmogrifier is used for examples, but applies to pipeline lambdas and TIM as well.

1- Transmogrifier does **not** set `--verbose`, **does** set `TDA_LOG_LEVEL=DEBUG`, resulting in duplicate DEBUG logging
- without `--verbose`, Transmog does not perform any logger filtering (supression)
- however, without `--verbose`, we must rely on `TDA_LOG_LEVEL` to prompt `DEBUG` logs from TDA

Example of debug logging:
```
2025-01-14 11:35:05,171 DEBUG timdex_dataset_api.dataset.get_dataset_record_batches() line 369: Yielding batch 0, row count: 1000
2025-01-14 11:35:05,171 DEBUG timdex_dataset_api.dataset.get_dataset_record_batches(): Yielding batch 0, row count: 1000
2025-01-14 11:35:05,174 DEBUG timdex_dataset_api.dataset.get_dataset_record_batches() line 369: Yielding batch 1, row count: 1
2025-01-14 11:35:05,174 DEBUG timdex_dataset_api.dataset.get_dataset_record_batches(): Yielding batch 1, row count: 1
```

This is because TDA was setting up its own handler when it was geared towards ensuring that `DEBUG` logs were showing up in Transmog.

2- Transmogrifier **does** set `--verbose`, resulting in zero TDA logs
- when `--verbose` used, Transmog filters out (supresses) other modules logging
- otherwise, this would have been a handy way for calling context to propagate logging level to imported modules

The proposed solution is to remove adding of handlers by the TDA library and relying explicitly on the calling application.  This is a best practice anyways: if the calling application is piping logs to another format (e.g. cloudwatch, logzio, etc.) we want all logging messages from all modules to be included.  If TDA sets up it's own handlers it may "look" correct in the terminal sometimes, but it's brittle; it just so happens that TDA and Transmog both output to the console.  

Sickle is an OAI-PMH python library and [demonstrates the ultimate in simplicity for logging](https://github.com/mloesch/sickle/blob/master/sickle/app.py#L21).  This lacks configurability like `TDA_LOG_LEVEL` which allows us to adjust the logging level of TDA independent of the calling application (libraries like pandas and pyarrow does this as well), but it demonstrates that you rely on the calling application's logging handlers.

For this to fully work, we will need to update Transmogrifier, pipeline lambdas, and TIM to remove the filtering of logs, e.g. [here for Transmog](https://github.com/MITLibraries/transmogrifier/blob/main/transmogrifier/config.py#L142-L143), and calls of `logging.basicConfig()`.  But hopefully this aligns with some proposed logging updates.  An example of how an updated `configure_logger()` function in calling applications could/should look:

```python
def configure_logger(logger: logging.Logger, verbose: bool) -> str:  # noqa: FBT001
    if verbose:
        logger.setLevel(logging.DEBUG)
        format = (
            "%(asctime)s %(levelname)s %(name)s.%(funcName)s() "
            "line %(lineno)d: %(message)s"
        )
    else:
        logger.setLevel(logging.INFO)
        format = "%(asctime)s %(levelname)s %(name)s.%(funcName)s(): %(message)s"

    handler = logging.StreamHandler()
    handler.setFormatter(logging.Formatter(format))
    logger.addHandler(handler)

    return (
        f"Logger '{logger.name}' configured with level="
        f"{logging.getLevelName(logger.getEffectiveLevel())}"
    )
```


### How can a reviewer manually see the effects of these changes?

#### Recreate the issue

For the current state of Transmogrifier `main` branch, the following should show duplicating log lines (as copy/pasted above):

```shell
pipenv run transform \
-s libguides \
-i tests/fixtures/dataset/libguides-2025-01-09-full-extracted-records-to-index.xml \
-o /tmp/dataset
```

#### Local development of TDA

```python
import logging
from timdex_dataset_api.config import configure_logger

# default to INFO
logging.basicConfig(level=logging.INFO)

logger = configure_logger(__name__)

# works
logger.info("hello info world!")

# does not work
logger.debug("I do not show.")

# adjust logging level
logger.setLevel(logging.DEBUG)

# try again, works
logger.debug("I am here!")
```

The key here is the call of `logging.basicConfig()`.  Currently, our CLI applications use this approach, but it's a  bit of a hammer and only suggested for debugging or local testing.  If that is omitted, you see nothing, but it's actually more realistically simulating that some kind of logging handler is required.  For local development, it would basically be required to see logging output (not unlike other 3rd party, installable libraries).

#### From an application like Transmogrifier

With the proposed change above to Transmog's `configure_logger()`, here are some combinations and outputs.

1- No `--verbose`, no `TDA_LOG_LEVEL`

```
Loading .env environment variables...
2025-01-13 13:40:15,914 INFO transmogrifier.cli.main(): Logger 'root' configured with level=INFO
2025-01-13 13:40:15,914 INFO transmogrifier.cli.main(): No Sentry DSN found, exceptions will not be sent to Sentry
2025-01-13 13:40:15,914 INFO transmogrifier.cli.main(): Running transform for source libguides
2025-01-13 13:40:15,919 INFO transmogrifier.sources.transformer.get_run_data(): explicit run_id not passed, minting new UUID
2025-01-13 13:40:15,919 INFO transmogrifier.sources.transformer.get_run_data(): run_id set: '4a891273-be4e-4fe5-8e6b-b89b01b54037'
-----> 2025-01-13 13:40:17,076 INFO timdex_dataset_api.dataset.log_write_statistics(): Dataset write complete - elapsed: 1.15s, total files: 1, total rows: 1001, total size: 21246
2025-01-13 13:40:17,076 INFO transmogrifier.cli.main(): Completed transform, total records processed: 1001, transformed records: 1001, skipped records: 0, deleted records: 0
2025-01-13 13:40:17,076 INFO transmogrifier.cli.main(): Total time to complete transform: 0:00:01.161690
```
- note the line `INFO timdex_dataset_api.dataset.log_write_statistics(): Dataset write complete` which shows that TDA `INFO` logs are coming through

2- Still no `--verbose`, but now include `TDA_LOG_LEVEL=DEBUG`:

```
Loading .env environment variables...
2025-01-13 13:41:20,958 INFO transmogrifier.cli.main(): Logger 'root' configured with level=INFO
2025-01-13 13:41:20,958 INFO transmogrifier.cli.main(): No Sentry DSN found, exceptions will not be sent to Sentry
2025-01-13 13:41:20,958 INFO transmogrifier.cli.main(): Running transform for source libguides
2025-01-13 13:41:20,964 INFO transmogrifier.sources.transformer.get_run_data(): explicit run_id not passed, minting new UUID
2025-01-13 13:41:20,964 INFO transmogrifier.sources.transformer.get_run_data(): run_id set: '410b104b-dfa5-4d4c-af5a-64d94dfb4c41'
-----> 2025-01-13 13:41:22,142 DEBUG timdex_dataset_api.dataset.create_record_batches(): Yielding batch 1 for dataset writing.
-----> 2025-01-13 13:41:22,144 DEBUG timdex_dataset_api.dataset.create_record_batches(): Yielding batch 2 for dataset writing.
2025-01-13 13:41:22,160 INFO timdex_dataset_api.dataset.log_write_statistics(): Dataset write complete - elapsed: 1.19s, total files: 1, total rows: 1001, total size: 21246
2025-01-13 13:41:22,160 INFO transmogrifier.cli.main(): Completed transform, total records processed: 1001, transformed records: 1001, skipped records: 0, deleted records: 0
2025-01-13 13:41:22,160 INFO transmogrifier.cli.main(): Total time to complete transform: 0:00:01.202095
```
- Note the `DEBUG` lines with `Yielding batch...` from TDA

3- Now, with `--verbose` and without `TDA_LOG_LEVEL`:

```
lots of output ...
...
2025-01-13 13:42:20,385 DEBUG charset_normalizer.from_bytes() line 461: Encoding detection: ascii is most likely the one.
2025-01-13 13:42:20,386 DEBUG transmogrifier.sources.xml.springshare.get_links() line 75: Record ID guides/175846 has links that cannot be generated: missing dc:identifier
2025-01-13 13:42:20,399 DEBUG timdex_dataset_api.dataset.create_record_batches() line 367: Yielding batch 1 for dataset writing.
-----> 2025-01-13 13:42:20,400 DEBUG charset_normalizer.from_bytes() line 461: Encoding detection: ascii is most likely the one.
-----> 2025-01-13 13:42:20,401 DEBUG transmogrifier.sources.xml.springshare.get_links() line 75: Record ID guides/175846 has links that cannot be generated: missing dc:identifier
-----> 2025-01-13 13:42:20,402 DEBUG timdex_dataset_api.dataset.create_record_batches() line 367: Yielding batch 2 for dataset writing.
2025-01-13 13:42:20,413 INFO timdex_dataset_api.dataset.log_write_statistics() line 383: Dataset write complete - elapsed: 1.6s, total files: 1, total rows: 1001, total size: 21246
2025-01-13 13:42:20,414 INFO transmogrifier.cli.main() line 89: Completed transform, total records processed: 1001, transformed records: 1001, skipped records: 0, deleted records: 0
2025-01-13 13:42:20,414 INFO transmogrifier.cli.main() line 103: Total time to complete transform: 0:00:01.610298
```
- Note the TDA `DEBUG` lines are still present
- Importantly, note that BS4 `DEBUG` lines are also included, `DEBUG charset_normalizer.from_bytes()....`
  - this is a side effect, but arguably a good one; other libraries are having their `DEBUG` logs bubble up now

4- Lastly, with `--verbose` but `TDA_LOG_LEVEL=WARNING`

```
lots of output...
2025-01-13 13:44:02,532 DEBUG transmogrifier.sources.xml.springshare.get_links() line 75: Record ID guides/175846 has links that cannot be generated: missing dc:identifier
2025-01-13 13:44:02,546 DEBUG charset_normalizer.from_bytes() line 461: Encoding detection: ascii is most likely the one.
2025-01-13 13:44:02,547 DEBUG transmogrifier.sources.xml.springshare.get_links() line 75: Record ID guides/175846 has links that cannot be generated: missing dc:identifier
2025-01-13 13:44:02,563 INFO transmogrifier.cli.main() line 89: Completed transform, total records processed: 1001, transformed records: 1001, skipped records: 0, deleted records: 0
2025-01-13 13:44:02,564 INFO transmogrifier.cli.main() line 103: Total time to complete transform: 0:00:01.606722
```
- Note that we see _zero_ TDA logging, where our `TDA_LOG_LEVEL` was respected throughout

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: it will require complimentary changes to Transmog, pipeline lambdas, and TIM in their `configure_logger()` functions

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-427

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

