### PR TITLE
TIMX 465 - Add `run_record_offset` column to dataset

### DIFF
--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -16,6 +16,7 @@ def test_dataset_record_init_with_valid_run_date_parses_year_month_day():
         "run_type": "full",
         "action": "index",
         "run_id": "000-111-aaa-bbb",
+        "run_record_offset": 0,
     }
     record = DatasetRecord(**values)
 
@@ -37,6 +38,7 @@ def test_dataset_record_init_with_invalid_run_date_raise_error():
         "run_type": "full",
         "action": "index",
         "run_id": "000-111-aaa-bbb",
+        "run_record_offset": 0,
     }
 
     with pytest.raises(
@@ -55,6 +57,7 @@ def test_dataset_record_serialization():
         "run_type": "full",
         "action": "index",
         "run_id": "abc123",
+        "run_record_offset": 0,
     }
     dataset_record = DatasetRecord(**values)
 
@@ -67,6 +70,7 @@ def test_dataset_record_serialization():
         "run_type": "full",
         "action": "index",
         "run_id": "abc123",
+        "run_record_offset": 0,
         "year": "2024",
         "month": "12",
         "day": "01",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,6 +32,7 @@ def generate_sample_records(
             run_type=run_type,
             action=action,
             run_id=run_id,
+            run_record_offset=x,
         )
 
 

--- a/timdex_dataset_api/__init__.py
+++ b/timdex_dataset_api/__init__.py
@@ -3,7 +3,7 @@
 from timdex_dataset_api.dataset import TIMDEXDataset
 from timdex_dataset_api.record import DatasetRecord
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 __all__ = [
     "DatasetRecord",

--- a/timdex_dataset_api/dataset.py
+++ b/timdex_dataset_api/dataset.py
@@ -33,8 +33,9 @@ TIMDEX_DATASET_SCHEMA = pa.schema(
         pa.field("source", pa.string()),
         pa.field("run_date", pa.date32()),
         pa.field("run_type", pa.string()),
-        pa.field("run_id", pa.string()),
         pa.field("action", pa.string()),
+        pa.field("run_id", pa.string()),
+        pa.field("run_record_offset", pa.int32()),
         pa.field("year", pa.string()),
         pa.field("month", pa.string()),
         pa.field("day", pa.string()),
@@ -53,8 +54,9 @@ class DatasetFilters(TypedDict, total=False):
     source: str | None
     run_date: str | date | None
     run_type: str | None
-    run_id: str | None
     action: str | None
+    run_id: str | None
+    run_record_offset: int | None
     year: str | None
     month: str | None
     day: str | None

--- a/timdex_dataset_api/record.py
+++ b/timdex_dataset_api/record.py
@@ -18,15 +18,15 @@ class DatasetRecord:
     writing.
     """
 
-    # primary columns
     timdex_record_id: str = field()
     source_record: bytes = field()
     transformed_record: bytes = field()
     source: str = field()
     run_date: date = field(converter=strict_date_parse)
     run_type: str = field()
-    run_id: str = field()
     action: str = field()
+    run_id: str = field()
+    run_record_offset: int = field(default=None)
 
     @property
     def year(self) -> str:


### PR DESCRIPTION
### Purpose and background context

This PR adds a new integer column to the dataset, `run_record_offset`.  At this time, this column most directly supports random access reads, where a specific record is wanted from the dataset.  This is related to the "provenance" data that will be added to TIMDEX records as part of [TIMX-406](https://mitlibraries.atlassian.net/browse/TIMX-406).

When a record is encountered in Opensearch, ideally we could retrieve the source + transformed record quickly (time) and efficiently (bytes read) from the parquet dataset.  We will always know the `run_date` and `run_id`, which will scope us down to records only from that run, but this could be  in upwards of 3 million for a large run like `alma`.

Before the addition of this column, our best option was simply to filter -- either in pyarrow or DuckDB -- by the desired `timdex_record_id`.  Unfortunately, the nature of our `timdex_record_id` values make them poor for this kind of filtering:

1. they are not sorted when written to the dataset, merely yielded as encountered from source file(s)
2. they do not lend themselves to lexicographic (alphanumeric) sorting

Staying out of the weeds somewhat, this means that parquet libraries -- pyarrow, DuckDB, AWS Athena, etc. -- cannot fully utilize the parquet metadata to trim what data is read as efficiently as possible.

The addition of this `run_record_offset` column changes that.  As we yield records in Transmogrifier for writing we can quite easily include an incrementing integer for this column.  So for an `alma` run with 3m records, we'd see values from `0` - `3,000,000` for this column.

Finally, when filtering the dataset for this record, this column is excellent for libraries to use.  Parquet dataset filtering is a combination of two things:

1. eliminating files we don't need
2. eliminating **row groups** (smaller chunks in files) we don't need

In each row group metadata, the min and max values for each column are present and libraries can use this to skip them if a target value would not be present.  So if we're looking for record offset `240,777` libraries can be sure it will not be in a row group with `min = 0` and `max = 1000`, but _will_ be present in a row group with `min = 240,000` and `max = 241,000`.

A couple of observations:
- this `run_record_offset` begins at 0 for each run, and is helpful only in the context of that run
- we would most likely still pass the `timdex_record_id` + `run_record_offset` when retrieving a single record to be sure they match
- this column could be `NULL` without much effect, just poorer filtering capabilities
- we will store this value in the "provenance" section of the TIMDEX record in Opensearch
- we will likely create a new read method for retrieving a single record, but would like to wait until the provenance work is complete in Transmogrifier and we start establishing some records in S3 to test it against

### How can a reviewer manually see the effects of these changes?

First, start ipython shell:

```shell
pipenv run ipython
```

Next, generate a dataset with the new column, plus some fuzzing of `timdex_record_id` to simulate the non-sortability we actually encounter:

```python
import uuid
from timdex_dataset_api import  TIMDEXDataset
from tests.utils import generate_sample_records

td = TIMDEXDataset('/tmp/run-offsets')

runs = [
    (300_123, 'alma', '2024-01-01', 'daily', 'index', 'run-id-abc123'),
    (150_999, 'dspace', '2024-01-01', 'daily', 'index', 'run-id-def4456'),
    (42_123, 'libguides', '2024-02-01', 'full', 'index', 'run-id-ghi789'),
]
for num_records, source, run_date, run_type, action, run_id in runs:
    records = list(generate_sample_records(
        num_records,
        source=source,
        timdex_record_id_prefix=source,
        run_date=run_date,
        run_type=run_type,
        action=action,
        run_id=run_id,
    ))
    for record in records:
        record.timdex_record_id = f"{source}:{str(uuid.uuid4())}"  # simulates poor sortability
    td.write(records)
```

Lastly, we'll do some reading and confirm that using the offset is considerably faster:

```python
# reload the dataset, simulating a run_date + run_id that we know
td.load(run_date='2024-01-01', run_id='run-id-abc123')

# simulate getting data from the TIMDEX provenance object in Opensearch
run_record_offset = 292_777
target_timdex_record_id = td.read_dataframe().iloc[run_record_offset].timdex_record_id

# first, use the magic %timeit to find the record by timdex_record_id
%timeit td.read_dataframe(run_date='2024-01-01', run_id='run-id-abc123', timdex_record_id=target_timdex_record_id).iloc[0]

# second, use the magic %timeit to find the record by offset
%timeit td.read_dataframe(run_date='2024-01-01', run_id='run-id-abc123', run_record_offset=run_record_offset).iloc[0]
```

For both of those `%timeit` runs, note the first value (e.g. `35.5 ms`) which is the average time in microseconds (it may appear to take longer, but also look at the "XXX loops each", where the offset approach actually runs 100 times while the first one only runs 10 times).  In my local testing, the offset based approach was generally 6-7x faster, and likely considerably more given network latency from S3.  It may seem somewhat inconsequential at this scale, but this new column provides a sorted column that leans into parquet row group metadata functionality.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: Transmogrifier will need to calculate and include a `run_record_offset` for each record yielded for writing, and include this in the record's `timdex_provenance` object

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-465

### Developer
- [x] All new ENV is documented in README
- [x] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes



[TIMX-406]: https://mitlibraries.atlassian.net/browse/TIMX-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ