### PR TITLE
Add support for 'or' conditions to filtering method

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -115,6 +115,22 @@ def test_dataset_load_with_multi_nonpartition_filters_success(fixed_local_datase
     assert fixed_local_dataset.row_count == 1
 
 
+def test_dataset_get_filtered_dataset_with_single_nonpartition_success(
+    fixed_local_dataset,
+):
+    fixed_local_dataset.load()  # initial load dataset, no filters passed
+
+    filtered_local_dataset = fixed_local_dataset._get_filtered_dataset(
+        run_id="abc123",
+    )
+    filtered_local_df = filtered_local_dataset.to_table().to_pandas()
+
+    # fixed_local_dataset consists of single 'run_id' value
+    # therefore, filtered_local_dataset includes all records
+    assert len(filtered_local_df) == filtered_local_dataset.count_rows()
+    assert filtered_local_df["run_id"].unique() == ["abc123"]
+
+
 def test_dataset_get_filtered_dataset_with_multi_nonpartition_filters_success(
     fixed_local_dataset,
 ):
@@ -133,20 +149,17 @@ def test_dataset_get_filtered_dataset_with_multi_nonpartition_filters_success(
     assert filtered_local_df["timdex_record_id"].iloc[0] == "alma:0"
 
 
-def test_dataset_get_filtered_dataset_with_single_nonpartition_success(
+def test_dataset_get_filtered_dataset_with_or_nonpartition_filters_success(
     fixed_local_dataset,
 ):
-    fixed_local_dataset.load()  # initial load dataset, no filters passed
+    fixed_local_dataset.load()
 
     filtered_local_dataset = fixed_local_dataset._get_filtered_dataset(
-        run_id="abc123",
+        timdex_record_id=["alma:0", "alma:1"]
     )
     filtered_local_df = filtered_local_dataset.to_table().to_pandas()
-
-    # fixed_local_dataset consists of single 'run_id' value
-    # therefore, filtered_local_dataset includes all records
-    assert len(filtered_local_df) == filtered_local_dataset.count_rows()
-    assert filtered_local_df["run_id"].unique() == ["abc123"]
+    assert len(filtered_local_df) == 2  # noqa: PLR2004
+    assert filtered_local_df["timdex_record_id"].tolist() == ["alma:0", "alma:1"]
 
 
 def test_dataset_get_filtered_dataset_with_run_date_str_successs(fixed_local_dataset):

--- a/timdex_dataset_api/dataset.py
+++ b/timdex_dataset_api/dataset.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, TypedDict, Unpack
 import boto3
 import pandas as pd
 import pyarrow as pa
-import pyarrow.compute as pc
 import pyarrow.dataset as ds
 from pyarrow import fs
 
@@ -171,8 +170,10 @@ class TIMDEXDataset:
         # create filter expressions for element-wise equality comparisons
         expressions = []
         for field, value in filters.items():
-            if value:
-                expressions.append(pc.equal(pc.field(field), value))
+            if isinstance(value, list):
+                expressions.append(ds.field(field).isin(value))
+            else:
+                expressions.append(ds.field(field) == value)
 
         # if filter expressions not found, return original dataset
         if not expressions:


### PR DESCRIPTION
### Purpose and background context
This PR updates the filtering method, `Dataset._get_filtered_dataset` to support `or` conditions for a given field (i.e., multiple possible values for a column). This is accomplished by [updating the code to check whether the value provided for a `DatasetFilter` (i.e., passed as a keyword argument) is a `list](https://github.com/MITLibraries/timdex-dataset-api/pull/99/files#diff-fb40971da01d2dcbf97cdad92e2c3f6656d1eaa201505a2f9074e5d52e452142R173-R176)`, and if so, to create the following expression:

```python
ds.field(field).isin(value)
```

**Note:** While the ticket proposes to consider supporting advanced filtering (e.g., `>=`, `<=`, etc.),  I opted to work on a known use-case--supporting "or" conditions for `DatasetFilter` columns.

### How can a reviewer manually see the effects of these changes?

Review [added unit test](https://github.com/MITLibraries/timdex-dataset-api/pull/99/files#diff-26199baaf391361625bd6773b9df4ed2677df4680a9650d2731510adec4898eaR152-R162), which filters the `fixed_local_dataset` filter to rows where `timdex_record_id.isin(<2-timdex-record-ids>)`.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES - This allows us to remove [a temporary workaround in `timdex-pipeline-lambdas` when counting the number of records for a `bulk-update`](https://github.com/MITLibraries/timdex-pipeline-lambdas/pull/315/commits/1ada64a2a3666dbe7dd581f27f2d28bb97356ab2#diff-b0e339bfcc4e1cecf4e583e31689a4c3aa5765a7752adc4c73dc87d2a5091934R124-R126). Applications using TDA should not have to perform low-level Pyarrow commands.

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-456

### Developer
- [x] All new ENV is documented in README
- [x] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

