### PR TITLE
TIMX 468 - surface pyarrow read configs to address memory footprint

### DIFF
--- a/timdex_dataset_api/__init__.py
+++ b/timdex_dataset_api/__init__.py
@@ -3,7 +3,7 @@
 from timdex_dataset_api.dataset import TIMDEXDataset
 from timdex_dataset_api.record import DatasetRecord
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 __all__ = [
     "DatasetRecord",

--- a/timdex_dataset_api/dataset.py
+++ b/timdex_dataset_api/dataset.py
@@ -3,9 +3,11 @@
 import itertools
 import json
 import operator
+import os
 import time
 import uuid
 from collections.abc import Iterator
+from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
 from functools import reduce
 from typing import TYPE_CHECKING, TypedDict, Unpack
@@ -61,20 +63,48 @@ class DatasetFilters(TypedDict, total=False):
     day: str | None
 
 
-DEFAULT_BATCH_SIZE = 1_000
-MAX_ROWS_PER_GROUP = DEFAULT_BATCH_SIZE
-MAX_ROWS_PER_FILE = 100_000
-DEFAULT_BATCH_READ_AHEAD = 0
-DEFAULT_FRAGMENT_READ_AHEAD = 0
+@dataclass
+class TIMDEXDatasetConfig:
+    """Configurations for dataset operations.
 
+    - read_batch_size: row size of batches read, affecting memory consumption
+    - write_batch_size: row size of batches written, directly affecting row group size in
+        final parquet files
+    - max_rows_per_group: max number of rows per row group in a parquet file
+    - max_rows_per_file: max number of rows in a single parquet file
+    - batch_read_ahead: number of batches to optimistically read ahead when batch reading
+        from a dataset; pyarrow default is 16
+    - fragment_read_ahead: number of fragments to optimistically read ahead when batch
+        reaching from a dataset; pyarrow default is 4
+    """
 
-def strict_date_parse(date_string: str) -> date:
-    return datetime.strptime(date_string, "%Y-%m-%d").astimezone(UTC).date()
+    read_batch_size: int = field(
+        default_factory=lambda: int(os.getenv("TDA_READ_BATCH_SIZE", "1_000"))
+    )
+    write_batch_size: int = field(
+        default_factory=lambda: int(os.getenv("TDA_WRITE_BATCH_SIZE", "1_000"))
+    )
+    max_rows_per_group: int = field(
+        default_factory=lambda: int(os.getenv("TDA_MAX_ROWS_PER_GROUP", "1_000"))
+    )
+    max_rows_per_file: int = field(
+        default_factory=lambda: int(os.getenv("TDA_MAX_ROWS_PER_FILE", "100_000"))
+    )
+    batch_read_ahead: int = field(
+        default_factory=lambda: int(os.getenv("TDA_BATCH_READ_AHEAD", "0"))
+    )
+    fragment_read_ahead: int = field(
+        default_factory=lambda: int(os.getenv("TDA_FRAGMENT_READ_AHEAD", "0"))
+    )
 
 
 class TIMDEXDataset:
 
-    def __init__(self, location: str | list[str]):
+    def __init__(
+        self,
+        location: str | list[str],
+        config: TIMDEXDatasetConfig | None = None,
+    ):
         """Initialize TIMDEXDataset object.
 
         Args:
@@ -82,6 +112,8 @@ class TIMDEXDataset:
                 a parquet dataset. For partitioned datasets, set to the base directory.
         """
         self.location = location
+        self.config = config or TIMDEXDatasetConfig()
+
         self.filesystem, self.source = self.parse_location(self.location)
         self.dataset: ds.Dataset = None  # type: ignore[assignment]
         self.schema = TIMDEX_DATASET_SCHEMA
@@ -171,7 +203,7 @@ class TIMDEXDataset:
 
         # create filter expressions for element-wise equality comparisons
         expressions = []
-        for field, value in filters.items():
+        for field, value in filters.items():  # noqa: F402
             if isinstance(value, list):
                 expressions.append(ds.field(field).isin(value))
             else:
@@ -207,7 +239,7 @@ class TIMDEXDataset:
             DatasetFilters[dict]: values for run_date, year, month, and day
         """
         if isinstance(run_date, str):
-            run_date_obj = strict_date_parse(run_date)
+            run_date_obj = datetime.strptime(run_date, "%Y-%m-%d").astimezone(UTC).date()
         elif isinstance(run_date, date):
             run_date_obj = run_date
         else:
@@ -286,7 +318,6 @@ class TIMDEXDataset:
         self,
         records_iter: Iterator["DatasetRecord"],
         *,
-        batch_size: int = DEFAULT_BATCH_SIZE,
         use_threads: bool = True,
     ) -> list[ds.WrittenFile]:
         """Write records to the TIMDEX parquet dataset.
@@ -309,8 +340,6 @@ class TIMDEXDataset:
 
         Args:
             - records_iter: Iterator of DatasetRecord instances
-            - batch_size: size for batches to yield and write, directly affecting row
-                group size in final parquet files
             - use_threads: boolean if threads should be used for writing
         """
         start_time = time.perf_counter()
@@ -321,10 +350,7 @@ class TIMDEXDataset:
                 "Dataset location must be the root of a single dataset for writing"
             )
 
-        record_batches_iter = self.create_record_batches(
-            records_iter,
-            batch_size=batch_size,
-        )
+        record_batches_iter = self.create_record_batches(records_iter)
 
         ds.write_dataset(
             record_batches_iter,
@@ -335,8 +361,8 @@ class TIMDEXDataset:
             file_visitor=lambda written_file: self._written_files.append(written_file),  # type: ignore[arg-type]
             format="parquet",
             max_open_files=500,
-            max_rows_per_file=MAX_ROWS_PER_FILE,
-            max_rows_per_group=MAX_ROWS_PER_GROUP,
+            max_rows_per_file=self.config.max_rows_per_file,
+            max_rows_per_group=self.config.max_rows_per_group,
             partitioning=self.partition_columns,
             partitioning_flavor="hive",
             schema=self.schema,
@@ -349,8 +375,6 @@ class TIMDEXDataset:
     def create_record_batches(
         self,
         records_iter: Iterator["DatasetRecord"],
-        *,
-        batch_size: int = DEFAULT_BATCH_SIZE,
     ) -> Iterator[pa.RecordBatch]:
         """Yield pyarrow.RecordBatches for writing.
 
@@ -361,10 +385,10 @@ class TIMDEXDataset:
 
         Args:
             - records_iter: Iterator of DatasetRecord instances
-            - batch_size: size for batches to yield and write, directly affecting row
-                group size in final parquet files
         """
-        for i, record_batch in enumerate(itertools.batched(records_iter, batch_size)):
+        for i, record_batch in enumerate(
+            itertools.batched(records_iter, self.config.write_batch_size)
+        ):
             batch = pa.RecordBatch.from_pylist(
                 [record.to_dict() for record in record_batch]
             )
@@ -395,9 +419,6 @@ class TIMDEXDataset:
     def read_batches_iter(
         self,
         columns: list[str] | None = None,
-        batch_size: int = DEFAULT_BATCH_SIZE,
-        batch_read_ahead: int = DEFAULT_BATCH_READ_AHEAD,
-        fragment_read_ahead: int = DEFAULT_FRAGMENT_READ_AHEAD,
         **filters: Unpack[DatasetFilters],
     ) -> Iterator[pa.RecordBatch]:
         """Yield pyarrow.RecordBatches from the dataset.
@@ -416,7 +437,7 @@ class TIMDEXDataset:
                 number will increase RAM usage but could also improve IO utilization.
                 Pyarrow default is 4, but this library defaults to 0 to prioritize memory
                 footprint.
-            - filter_kwargs: pairs of column:value to filter the dataset
+            - filters: pairs of column:value to filter the dataset
         """
         if not self.dataset:
             raise DatasetNotLoadedError(
@@ -425,9 +446,9 @@ class TIMDEXDataset:
         dataset = self._get_filtered_dataset(**filters)
         for batch in dataset.to_batches(
             columns=columns,
-            batch_size=batch_size,
-            batch_readahead=batch_read_ahead,
-            fragment_readahead=fragment_read_ahead,
+            batch_size=self.config.read_batch_size,
+            batch_readahead=self.config.batch_read_ahead,
+            fragment_readahead=self.config.fragment_read_ahead,
         ):
             if len(batch) > 0:
                 yield batch
@@ -435,9 +456,6 @@ class TIMDEXDataset:
     def read_dataframes_iter(
         self,
         columns: list[str] | None = None,
-        batch_size: int = DEFAULT_BATCH_SIZE,
-        batch_read_ahead: int = DEFAULT_BATCH_READ_AHEAD,
-        fragment_read_ahead: int = DEFAULT_FRAGMENT_READ_AHEAD,
         **filters: Unpack[DatasetFilters],
     ) -> Iterator[pd.DataFrame]:
         """Yield record batches as Pandas DataFrames from the dataset.
@@ -446,9 +464,6 @@ class TIMDEXDataset:
         """
         for record_batch in self.read_batches_iter(
             columns=columns,
-            batch_size=batch_size,
-            batch_read_ahead=batch_read_ahead,
-            fragment_read_ahead=fragment_read_ahead,
             **filters,
         ):
             yield record_batch.to_pandas()
@@ -456,9 +471,6 @@ class TIMDEXDataset:
     def read_dataframe(
         self,
         columns: list[str] | None = None,
-        batch_size: int = DEFAULT_BATCH_SIZE,
-        batch_read_ahead: int = DEFAULT_BATCH_READ_AHEAD,
-        fragment_read_ahead: int = DEFAULT_FRAGMENT_READ_AHEAD,
         **filters: Unpack[DatasetFilters],
     ) -> pd.DataFrame | None:
         """Yield record batches as Pandas DataFrames and concatenate to single dataframe.
@@ -473,9 +485,6 @@ class TIMDEXDataset:
             record_batch.to_pandas()
             for record_batch in self.read_batches_iter(
                 columns=columns,
-                batch_size=batch_size,
-                batch_read_ahead=batch_read_ahead,
-                fragment_read_ahead=fragment_read_ahead,
                 **filters,
             )
         ]
@@ -486,9 +495,6 @@ class TIMDEXDataset:
     def read_dicts_iter(
         self,
         columns: list[str] | None = None,
-        batch_size: int = DEFAULT_BATCH_SIZE,
-        batch_read_ahead: int = DEFAULT_BATCH_READ_AHEAD,
-        fragment_read_ahead: int = DEFAULT_FRAGMENT_READ_AHEAD,
         **filters: Unpack[DatasetFilters],
     ) -> Iterator[dict]:
         """Yield individual record rows as dictionaries from the dataset.
@@ -497,18 +503,12 @@ class TIMDEXDataset:
         """
         for record_batch in self.read_batches_iter(
             columns=columns,
-            batch_size=batch_size,
-            batch_read_ahead=batch_read_ahead,
-            fragment_read_ahead=fragment_read_ahead,
             **filters,
         ):
             yield from record_batch.to_pylist()
 
     def read_transformed_records_iter(
         self,
-        batch_size: int = DEFAULT_BATCH_SIZE,
-        batch_read_ahead: int = DEFAULT_BATCH_READ_AHEAD,
-        fragment_read_ahead: int = DEFAULT_FRAGMENT_READ_AHEAD,
         **filters: Unpack[DatasetFilters],
     ) -> Iterator[dict]:
         """Yield individual transformed records as dictionaries from the dataset.
@@ -520,9 +520,6 @@ class TIMDEXDataset:
         """
         for record_dict in self.read_dicts_iter(
             columns=["transformed_record"],
-            batch_size=batch_size,
-            batch_read_ahead=batch_read_ahead,
-            fragment_read_ahead=fragment_read_ahead,
             **filters,
         ):
             if transformed_record := record_dict["transformed_record"]:


### PR DESCRIPTION
### Purpose and background context

#### Part One: expose read configurations and fix memory issue

Commit: https://github.com/MITLibraries/timdex-dataset-api/pull/108/commits/ad3f6bd09aa5a59223360b3c1e933f16631f704a

This PR exposes two important read configurations from pyarrow's `Dataset.to_batches()` to this library, such that new, TIMDEX-aligned defaults can be set, but also are available for more advanced tuning when needed.

These configurations are both part of [`Dataset.to_batches()`](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Dataset.html#pyarrow.dataset.Dataset.to_batches):
- `batch_readahead`
- `fragment_readahead`

We faced an out-of-memory (OOM) error when TIM attempted to bulk index to Opensearch for a large run of Alma.  This was surprising as all parts of the reading + indexing pipeline were generators, yielding small dictionaries, then disposing of them.

It turns out that pyarrow was optimisitically reading batches ahead of time to increase IO.  Normally, this is a great thing!  But for our purposes, with ECS Fargate containers with fairly minimal memory resources, it's not ideal.  And the performance gain is really not worth the resource increases we'd need.

These configurations are available for precisely this reason, and are a good fit for exposing to this TDA library.

#### Part Two: create new `TIMDEXDatasetConfig` object

Commit: https://github.com/MITLibraries/timdex-dataset-api/pull/108/commits/614d6fa93a15200f56ade9742cc5c1a7fd7876b1

While adding these read configurations, it was clear they'd need to be mirrored in all read methods.  This felt cumbersome.  When adding them as constants near the top, it revealed how much they had grown as well.  This felt like an ideal time to refactor to use a typed, consistent, with-defaults configuration object that we pass to a `TIMDEXDataset` on init.

### How can a reviewer manually see the effects of these changes?

1- Set Dev1 AWS credentials

2- Start Ipython shell
```shell
pipenv run ipython
```

3- Load Dev1 dataset:
```python
from timdex_dataset_api import TIMDEXDataset
LOCATION = 's3://timdex-extract-dev-222053980223/dataset/'
td = TIMDEXDataset(LOCATION)
td.load(
    run_date="2025-02-03",
    run_id="c2d56168-8fb5-4111-9432-9d59bda22fcf"
)
```

For the following two, you'll want to run something like `btop` or activity monitor to see the memory usage for the Ipython process.  **AND, you'll want to Ctrl + C after 10-15 seconds, otherwise it'll loop  through all 3m records 😎**

4- Demonstrate high memory usage when read ahead are pyarrow defaults
```python
td.config.batch_read_ahead = 16 # pyarrow default
td.config.fragment_read_ahead = 4 # pyarrow default
for i, d in enumerate(td.read_batches_iter(
columns=['transformed_record'],
        action='index'
    )
):
    print(i)
```

![large_read_ahead](https://github.com/user-attachments/assets/61bec22c-cdb1-494c-9a0d-f0c0a1e45f6c)
_Watch the `MemB` number in the lower right..._

5- Demonstrate low memory usage when read ahead are new TDA defaults
```python
td.config.batch_read_ahead = 0 # TDA default
td.config.fragment_read_ahead = 0 # TDA default
for i, d in enumerate(td.read_batches_iter(
columns=['transformed_record'],
        action='index'
    )
):
    print(i)
```

![small_read_ahead](https://github.com/user-attachments/assets/c15432a0-6b3c-4ed4-a138-353a4f0a4676)
_Watch the `MemB` number in the lower right..._

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: by default, TIM should not experience out of memory issues

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-468

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

