### PR TITLE
TIMX 494 - TIMDEXRunManager for producing ETL run metadata

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 # ruff: noqa: D205, D209
 
+import os
 
 import pytest
 
@@ -10,6 +11,7 @@ from tests.utils import (
     generate_sample_records_with_simulated_partitions,
 )
 from timdex_dataset_api import TIMDEXDataset
+from timdex_dataset_api.dataset import TIMDEXDatasetConfig
 
 
 @pytest.fixture(autouse=True)
@@ -90,3 +92,58 @@ def sample_records_iter_without_partitions():
         )
 
     return _records_iter
+
+
+@pytest.fixture
+def dataset_with_runs_location(tmp_path) -> str:
+    """Fixture to simulate a dataset with multiple full and daily ETL runs."""
+    location = str(tmp_path / "dataset_with_runs")
+    os.mkdir(location)
+
+    timdex_dataset = TIMDEXDataset(
+        location, config=TIMDEXDatasetConfig(max_rows_per_group=75, max_rows_per_file=75)
+    )
+    timdex_dataset.load()
+
+    run_params = []
+
+    # simulate ETL runs for 'alma'
+    run_params.extend(
+        [
+            (40, "alma", "2024-12-01", "full", "index", "run-1"),
+            (20, "alma", "2024-12-15", "daily", "index", "run-2"),
+            (100, "alma", "2025-01-01", "full", "index", "run-3"),
+            (50, "alma", "2025-01-02", "daily", "index", "run-4"),
+            (25, "alma", "2025-01-03", "daily", "index", "run-5"),
+            (10, "alma", "2025-01-04", "daily", "delete", "run-6"),
+            (9, "alma", "2025-01-05", "daily", "index", "run-7"),
+        ]
+    )
+
+    # simulate ETL runs for 'alma'
+    run_params.extend(
+        [
+            (30, "dspace", "2024-12-02", "full", "index", "run-8"),
+            (10, "dspace", "2024-12-16", "daily", "index", "run-9"),
+            (90, "dspace", "2025-02-01", "full", "index", "run-10"),
+            (40, "dspace", "2025-02-02", "daily", "index", "run-11"),
+            (15, "dspace", "2025-02-03", "daily", "index", "run-12"),
+            (5, "dspace", "2025-02-04", "daily", "delete", "run-13"),
+            (4, "dspace", "2025-02-05", "daily", "index", "run-14"),
+        ]
+    )
+
+    # write to dataset
+    for params in run_params:
+        num_records, source, run_date, run_type, action, run_id = params
+        records = generate_sample_records(
+            num_records,
+            source=source,
+            run_date=run_date,
+            run_type=run_type,
+            action=action,
+            run_id=run_id,
+        )
+        timdex_dataset.write(records)
+
+    return location

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,7 +120,7 @@ def dataset_with_runs_location(tmp_path) -> str:
         ]
     )
 
-    # simulate ETL runs for 'alma'
+    # simulate ETL runs for 'dspace'
     run_params.extend(
         [
             (30, "dspace", "2024-12-02", "full", "index", "run-8"),

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -1,0 +1,85 @@
+# ruff: noqa: SLF001, D205, D209, PLR2004
+
+import datetime
+from unittest.mock import patch
+
+import pytest
+
+from timdex_dataset_api import TIMDEXDataset
+from timdex_dataset_api.run import TIMDEXRunManager
+
+
+@pytest.fixture
+def timdex_run_manager(dataset_with_runs_location):
+    timdex_dataset = TIMDEXDataset(dataset_with_runs_location)
+    return TIMDEXRunManager(timdex_dataset=timdex_dataset)
+
+
+def test_timdex_run_manager_init(dataset_with_runs_location):
+    timdex_dataset = TIMDEXDataset(dataset_with_runs_location)
+    timdex_run_manager = TIMDEXRunManager(timdex_dataset=timdex_dataset)
+    assert timdex_run_manager._runs_metadata_cache is None
+
+
+def test_timdex_run_manager_parse_single_parquet_file_success(timdex_run_manager):
+    """Parse run metadata from first parquet file in fixture dataset.  We know the details
+    of this ETL run in advance given the deterministic fixture that generated it."""
+    parquet_filepath = timdex_run_manager.timdex_dataset.dataset.files[0]
+    run_metadata = timdex_run_manager.parse_run_metadata_from_parquet_file(
+        parquet_filepath
+    )
+    assert run_metadata["source"] == "alma"
+    assert run_metadata["run_date"] == datetime.date(2024, 12, 1)
+    assert run_metadata["run_type"] == "full"
+    assert run_metadata["run_id"] == "run-1"
+    assert run_metadata["num_rows"] == 40
+    assert run_metadata["filename"] == parquet_filepath
+
+
+def test_timdex_run_manager_parse_multiple_parquet_files(timdex_run_manager):
+    parquet_metadata_df = timdex_run_manager.get_parquet_files_run_metadata()
+
+    # assert 16 rows for this per-file dataframe, despite only 14 distinct ETL "runs"
+    assert len(parquet_metadata_df) == 16
+
+    # assert each source has metadata for 8 parquet files
+    assert parquet_metadata_df.source.value_counts().to_dict() == {"alma": 8, "dspace": 8}
+
+
+def test_timdex_run_manager_get_runs_df(timdex_run_manager):
+    runs_df = timdex_run_manager.get_runs_metadata()
+
+    # assert two "large" runs have multiple parquet files
+    assert len(runs_df[runs_df.parquet_files_count > 1]) == 2
+
+    # assert 7 distinct runs per source, despite more parquet files
+    assert runs_df.source.value_counts().to_dict() == {"alma": 7, "dspace": 7}
+
+
+def test_timdex_run_manager_get_source_current_run_parquet_files_success(
+    timdex_run_manager,
+):
+    ordered_parquet_files = timdex_run_manager.get_current_source_parquet_files("alma")
+
+    # assert 6 parquet files, despite being 8 total for alma
+    # this represents the last full run and all daily since
+    assert len(ordered_parquet_files)
+
+    # assert sorted reverse chronologically
+    assert "year=2025/month=01/day=05" in ordered_parquet_files[0]
+    assert "year=2025/month=01/day=01" in ordered_parquet_files[-1]
+
+
+def test_timdex_run_manager_caches_runs_dataframe(timdex_run_manager):
+    runs_df = timdex_run_manager.get_runs_metadata()
+    assert timdex_run_manager._runs_metadata_cache is not None
+
+    with patch.object(
+        timdex_run_manager, "get_parquet_files_run_metadata"
+    ) as mocked_intermediate_method:
+        mocked_intermediate_method.side_effect = Exception(
+            "I am not reached, cache is used."
+        )
+        runs_df_2 = timdex_run_manager.get_runs_metadata()
+
+    assert runs_df.equals(runs_df_2)

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -25,7 +25,7 @@ def test_timdex_run_manager_parse_single_parquet_file_success(timdex_run_manager
     """Parse run metadata from first parquet file in fixture dataset.  We know the details
     of this ETL run in advance given the deterministic fixture that generated it."""
     parquet_filepath = timdex_run_manager.timdex_dataset.dataset.files[0]
-    run_metadata = timdex_run_manager.parse_run_metadata_from_parquet_file(
+    run_metadata = timdex_run_manager._parse_run_metadata_from_parquet_file(
         parquet_filepath
     )
     assert run_metadata["source"] == "alma"
@@ -37,7 +37,7 @@ def test_timdex_run_manager_parse_single_parquet_file_success(timdex_run_manager
 
 
 def test_timdex_run_manager_parse_multiple_parquet_files(timdex_run_manager):
-    parquet_metadata_df = timdex_run_manager.get_parquet_files_run_metadata()
+    parquet_metadata_df = timdex_run_manager._get_parquet_files_run_metadata()
 
     # assert 16 rows for this per-file dataframe, despite only 14 distinct ETL "runs"
     assert len(parquet_metadata_df) == 16
@@ -75,7 +75,7 @@ def test_timdex_run_manager_caches_runs_dataframe(timdex_run_manager):
     assert timdex_run_manager._runs_metadata_cache is not None
 
     with patch.object(
-        timdex_run_manager, "get_parquet_files_run_metadata"
+        timdex_run_manager, "_get_parquet_files_run_metadata"
     ) as mocked_intermediate_method:
         mocked_intermediate_method.side_effect = Exception(
             "I am not reached, cache is used."

--- a/timdex_dataset_api/run.py
+++ b/timdex_dataset_api/run.py
@@ -1,0 +1,169 @@
+"""timdex_dataset_api/run.py"""
+
+import concurrent.futures
+import logging
+import time
+from typing import TYPE_CHECKING
+
+import pandas as pd
+import pyarrow.parquet as pq
+
+if TYPE_CHECKING:
+    from timdex_dataset_api.dataset import TIMDEXDataset
+
+logger = logging.getLogger(__name__)
+
+
+class TIMDEXRunManager:
+    """Manages and provides access to ETL run metadata from the TIMDEX parquet dataset."""
+
+    def __init__(self, timdex_dataset: "TIMDEXDataset"):
+        self.timdex_dataset: TIMDEXDataset = timdex_dataset
+        if self.timdex_dataset.dataset is None:
+            self.timdex_dataset.load()
+
+        self._runs_metadata_cache: pd.DataFrame | None = None
+
+    def clear_cache(self) -> None:
+        self._runs_metadata_cache = None
+
+    def parse_run_metadata_from_parquet_file(self, parquet_filepath: str) -> dict:
+        """Parse source, run_date, run_type, and run_id from a single Parquet file.
+
+        Args:
+            parquet_filepath: Path to the parquet file
+        """
+        parquet_file = pq.ParquetFile(
+            parquet_filepath,
+            filesystem=self.timdex_dataset.filesystem,  # type: ignore[union-attr]
+        )
+        file_meta = parquet_file.metadata.to_dict()
+        num_rows = file_meta["num_rows"]
+        columns_meta = file_meta["row_groups"][0]["columns"]  # type: ignore[typeddict-item]
+        source = columns_meta[3]["statistics"]["max"]
+        run_date = columns_meta[4]["statistics"]["max"]
+        run_type = columns_meta[5]["statistics"]["max"]
+        run_id = columns_meta[7]["statistics"]["max"]
+
+        return {
+            "source": source,
+            "run_date": run_date,
+            "run_type": run_type,
+            "run_id": run_id,
+            "num_rows": num_rows,
+            "filename": parquet_filepath,
+        }
+
+    def get_parquet_files_run_metadata(self, max_workers: int = 250) -> pd.DataFrame:
+        """Retrieve run metadata from parquet file(s) in dataset.
+
+        A single ETL run may still be spread across multiple Parquet files making this
+        data ungrouped by run.
+
+        Args:
+            max_workers: Maximum number of parallel workers for processing
+                - a high number is generally safe given the lightweight nature of the
+                thread's work, just reading a few parquet file header bytes
+        """
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = []
+            for parquet_filepath in self.timdex_dataset.dataset.files:  # type: ignore[attr-defined]
+                future = executor.submit(
+                    self.parse_run_metadata_from_parquet_file,
+                    parquet_filepath,
+                )
+                futures.append(future)
+
+            done, not_done = concurrent.futures.wait(
+                futures, return_when=concurrent.futures.ALL_COMPLETED
+            )
+
+            results = []
+            for future in done:
+                try:
+                    if result := future.result():
+                        results.append(result)
+                except Exception:
+                    logger.exception("Error reading run metadata from parquet file.")
+
+        return pd.DataFrame(results) if results else pd.DataFrame()
+
+    def get_runs_metadata(self, *, refresh: bool = False) -> pd.DataFrame:
+        """Get metadata for all runs in dataset, grouped by run_id.
+
+        Args:
+            refresh: If True, force refresh of cached metadata
+        """
+        start_time = time.perf_counter()
+
+        if self._runs_metadata_cache is not None and not refresh:
+            return self._runs_metadata_cache
+
+        ungrouped_runs_df = self.get_parquet_files_run_metadata()
+        if ungrouped_runs_df.empty:
+            return ungrouped_runs_df
+
+        # group by run_id
+        grouped_runs_df = (
+            ungrouped_runs_df.groupby("run_id")
+            .agg(
+                {
+                    "source": "first",
+                    "run_date": "first",
+                    "run_type": "first",
+                    "num_rows": "sum",
+                    "filename": list,
+                }
+            )
+            .reset_index()
+        )
+
+        # add additional metadata
+        grouped_runs_df = grouped_runs_df.rename(columns={"filename": "parquet_files"})
+        grouped_runs_df["parquet_files_count"] = grouped_runs_df["parquet_files"].apply(
+            lambda x: len(x)
+        )
+
+        # sort by run date and source
+        grouped_runs_df = grouped_runs_df.sort_values(
+            ["run_date", "source"], ascending=False
+        )
+
+        # cache the result
+        self._runs_metadata_cache = grouped_runs_df
+
+        logger.info(
+            f"Dataset runs metadata retrieved, elapsed: "
+            f"{round(time.perf_counter() - start_time, 2)}s, runs: {len(grouped_runs_df)}"
+        )
+        return grouped_runs_df
+
+    def get_current_source_parquet_files(self, source: str) -> list[str]:
+        """Get reverse chronological list of current parquet files for a source.
+
+        Args:
+            source: The source identifier to filter runs
+        """
+        runs_df = self.get_runs_metadata()
+        source_runs_df = runs_df[runs_df.source == source].copy()
+
+        # get last "full" run
+        full_runs_df = source_runs_df[source_runs_df.run_type == "full"]
+        if len(full_runs_df) == 0:
+            raise RuntimeError(
+                f"Could not find the most recent 'full' run for source: '{source}'"
+            )
+        last_full_run = full_runs_df.iloc[0]
+
+        # get all "daily" runs since
+        daily_runs_df = source_runs_df[
+            (source_runs_df.run_type == "daily")
+            & (source_runs_df.run_date >= last_full_run.run_date)
+        ]
+
+        ordered_parquet_files = []
+        for _, daily_run in daily_runs_df.iterrows():
+            ordered_parquet_files.extend(daily_run.parquet_files)
+        ordered_parquet_files.extend(last_full_run.parquet_files)
+
+        return ordered_parquet_files


### PR DESCRIPTION
### Purpose and background context

This PR adds a new class `TIMDEXRunManager` that is a utility class for efficiently gathering metadata about all runs in the TIMDEX parquet dataset.

The original requirements of this library were to support efficient writing and reading from the dataset over the course of a single ETL run.  For example Transmogrifier writes to the dataset where all records have a shared `run_id` and TIM reads from the dataset for that `run_id` and indexes those records to Opensearch.  This was made very efficient by the year/month/day partitioning strategy, where TIM instantly narrows it down to parquet files under those partitions and then just reads the metadata from those few parquet files to get the file(s) that match a `run_id`.  

However, it was assumed the dataset and this library would be capable of far more over time!  One known use case: providing easy access to all the records for a given TIMDEX source that are currently in Opensearch.  Let's think of this as the "current records for a source."  To provide this functionality, we first need some understanding of the "runs" in the dataset specific to that source, including the `run_date`, `run_type`, `run_id`, associated parquet file, etc.

While technically we could load the whole dataset and use pyarrow dataset filtering or DuckDB, this is quite inefficient.  This new class relies on some things we -- the dataset creators -- know about the dataset to support highly-parallelized run metadata retrieval:

- all rows in a given parquet file are from a single run, therefore metadata from a _single_ row tell us about the run as a whole
- we can collect this information in parallel and each request is very lightweight
- we can group by `run_id` to create a full picture of a run from this collected metadata

And this is precisely how this utility class approaches producing dataset runs metadata:

1. Accept an instantiated and loaded `TIMDEXDataset` which has a list of _all_ parquet files in the dataset
2. In parallel, read the metadata from the first row in each parquet file
3. Aggregate this and group by `run_id`
4. Returning a dataframe of run metadata across all runs in the dataset

This has proven to be very fast, around 1-2 seconds given even hundreds of parquet files.  With that final run metadata in hand, it paves the way for _future_ functionality like yielding only the currrent version of a record, for a source.
  

### How can a reviewer manually see the effects of these changes?

1- For all tests below, set AWS **Dev Admin** credentials (using a test bucket with a static clone of prod data)

2- Start an ipython shell:
```shell
pipenv run ipython
```

#### Sometimes an alternate approach can illuminate the proposed one.  Let's use DuckDB to get ETL run metadata.

Define a function that uses a SQL query to get at run data, grouping by `run_id`:

```python
import time

import duckdb

def get_source_etl_runs(source:str):
    t0 = time.perf_counter()
    with duckdb.connect() as conn:

        # setup AWS credentials
        conn.execute("""
        CREATE OR REPLACE SECRET aws_secret (
            TYPE s3,
            PROVIDER credential_chain,
            CHAIN 'env;sso;process'
        );
        """)

        # perform query
        query = f"""
        with dataset as (
            select * from read_parquet(
                's3://ghukill-test/timdex-dataset/prod_2025_05_05/**/*.parquet',
                filename=true
            )
        ),
        etl_runs as (
            select
                source,
                run_date,
                run_type,
                run_id,
                count(*) as num_rows,
                array_agg(filename) as parquet_files
            from dataset
            where source='{source}'
            group by run_date, source, run_type, run_id  -- here is the expensive part of the query
        )
        select
            *
        from etl_runs
        ;
        """
        result = conn.query(query).to_df()
        print(f"elapsed: {time.perf_counter() - t0}")
        return result
```

Now, let's run this for a few different sources:

```python
df1 = get_source_etl_runs('libguides')
100% ▕████████████████████████████████████████████████████████████▏ 
elapsed: 10.36918495898135

df2 = get_source_etl_runs('dspace')
100% ▕████████████████████████████████████████████████████████████▏ 
elapsed: 12.032363249920309

df3 = get_source_etl_runs('alma')
100% ▕████████████████████████████████████████████████████████████▏ 
elapsed: 120.38288041693158
```

The first run for `libguides` and even `dspace` looked promising: 10-12 seconds and low memory usage.  But what happened with `alma`?

Unfortunately, DuckDB doesn't know some things about our dataset that it could leverage.  It's amazing that it's this fast, but for `alma` we can see it's very briefly touching each row in the dataset to get that run ETL metadata, which is not needed.  Given that `alma` is by far the largest, getting ETL run data for _all_ sources would be about the same time (just a little slower).

We would see similar performance results using `pyarrow.dataset.filter()` and `pyarrow.dataset.group_by()`.

Though we want run-level metadata, we also know that for each parquet file its associated ETL run metadata is present in _every_ row, e.g. the _first, single_ row.  It's no shade on DuckDB or `pyarrow`, they simply don't know as much about dataset and thus touch much more data than needed.

This PR body probably isn't the best place for in-depth analysis of those approaches, but suffice to say, tried many angles and just couldn't get close to matching the performance of the custom class demonstrated next.

#### Now, let's use the `TIMDEXRunManager` to get the same data.

Configure the dev logger for more output:

```python
from timdex_dataset_api.config import configure_dev_logger

configure_dev_logger()
```

Next, load a normal `TIMDEXDataset` instance with represents the full dataset:

```python
from timdex_dataset_api import TIMDEXDataset

td = TIMDEXDataset("s3://ghukill-test/timdex-dataset/prod_2025_05_05")
td.load()
```

Note the quick load time, unchanged from before, discovering all parquet files in the dataset.

Observe how many parquet files comprise the dataset:

```python
print(len(td.dataset.files))
# 370
```

Now, load a `TIMDEXRunManager` instance and retrieve ETL run data for _all_ runs:

```python
from timdex_dataset_api.run import TIMDEXRunManager

ts = TIMDEXRunManager(timdex_dataset=td)
runs_df = ts.get_runs_metadata()
```

Metadata about all ~270 ETL runs comes back in about 1-3 seconds!  A fraction of a single, small source using DuckDB, and orders and orders magnitude faster than touching sources like `alma`.  Furthermore, this will continue to scale as the number of parquet files grows.

Lastly, let's get an ordered list of all parquet files for a given source that represent the "current" records in TIMDEX:

```python
parquet_files = ts.get_current_source_parquet_files('alma')
```

Note it's basically instant, given that we've cached the full dataframe of ETL run metadata.  If we had _not_ done that step yet, this would take that 1-3 seconds we saw above.

A valid question would now be, "what do we do with a list of reverse chronologically ordered parquet files?"  The answer is we use that list to load a _new_ `TIMDEXDataset` instance with those _specific, ordered_ parquet files.

This use of the valuable list of ordered, specific parquet files leads into a future PR which will utilize this valuable information to provide an efficient way to yield only "current" records for a given TIMDEX source.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/TIMX-493
* https://mitlibraries.atlassian.net/browse/TIMX-494

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

