### PR TITLE
TIMX 494 - yield deduped, most recent records

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,7 @@ def dataset_with_runs_location(tmp_path) -> str:
         num_records, source, run_date, run_type, action, run_id = params
         records = generate_sample_records(
             num_records,
+            timdex_record_id_prefix=source,
             source=source,
             run_date=run_date,
             run_type=run_type,
@@ -147,3 +148,8 @@ def dataset_with_runs_location(tmp_path) -> str:
         timdex_dataset.write(records)
 
     return location
+
+
+@pytest.fixture
+def local_dataset_with_runs(dataset_with_runs_location) -> TIMDEXDataset:
+    return TIMDEXDataset(dataset_with_runs_location)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -138,9 +138,13 @@ def test_dataset_load_with_multi_nonpartition_filters_success(fixed_local_datase
 
 def test_dataset_load_current_records_all_sources_success(dataset_with_runs_location):
     timdex_dataset = TIMDEXDataset(dataset_with_runs_location)
-    timdex_dataset.load(current_records=True)
 
-    # 14 total parquet files, only 12 related to current runs
+    # 16 total parquet files, with current_records=False we get them all
+    timdex_dataset.load(current_records=False)
+    assert len(timdex_dataset.dataset.files) == 16
+
+    # 16 total parquet files, with current_records=True we only get 12 for current runs
+    timdex_dataset.load(current_records=True)
     assert len(timdex_dataset.dataset.files) == 12
 
 

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -56,14 +56,27 @@ def test_timdex_run_manager_get_runs_df(timdex_run_manager):
     assert runs_df.source.value_counts().to_dict() == {"alma": 7, "dspace": 7}
 
 
+def test_timdex_run_manager_get_all_current_run_parquet_files_success(
+    timdex_run_manager,
+):
+    ordered_parquet_files = timdex_run_manager.get_current_parquet_files()
+
+    # assert 12 parquet files, despite being 14 total for ALL sources
+    # this represents the last full run and all daily since
+    assert len(ordered_parquet_files) == 12
+
+    # assert sorted reverse chronologically
+    assert "year=2025/month=01/day=01" in ordered_parquet_files[-1]
+
+
 def test_timdex_run_manager_get_source_current_run_parquet_files_success(
     timdex_run_manager,
 ):
     ordered_parquet_files = timdex_run_manager.get_current_source_parquet_files("alma")
 
-    # assert 6 parquet files, despite being 8 total for alma
+    # assert 6 parquet files, despite being 8 total for 'alma' source
     # this represents the last full run and all daily since
-    assert len(ordered_parquet_files)
+    assert len(ordered_parquet_files) == 6
 
     # assert sorted reverse chronologically
     assert "year=2025/month=01/day=05" in ordered_parquet_files[0]

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -72,7 +72,7 @@ def test_timdex_run_manager_get_all_current_run_parquet_files_success(
 def test_timdex_run_manager_get_source_current_run_parquet_files_success(
     timdex_run_manager,
 ):
-    ordered_parquet_files = timdex_run_manager.get_current_source_parquet_files("alma")
+    ordered_parquet_files = timdex_run_manager._get_current_source_parquet_files("alma")
 
     # assert 6 parquet files, despite being 8 total for 'alma' source
     # this represents the last full run and all daily since

--- a/timdex_dataset_api/__init__.py
+++ b/timdex_dataset_api/__init__.py
@@ -3,7 +3,7 @@
 from timdex_dataset_api.dataset import TIMDEXDataset
 from timdex_dataset_api.record import DatasetRecord
 
-__version__ = "1.0.0"
+__version__ = "2.0.0"
 
 __all__ = [
     "DatasetRecord",

--- a/timdex_dataset_api/dataset.py
+++ b/timdex_dataset_api/dataset.py
@@ -167,12 +167,12 @@ class TIMDEXDataset:
         if current_records:
             timdex_run_manager = TIMDEXRunManager(timdex_dataset=self)
 
-            # if filters.source is set, further limit to only this source
-            source = filters.get("source")
-            if source:
-                self.paths = timdex_run_manager.get_current_source_parquet_files(source)
-            else:
-                self.paths = timdex_run_manager.get_current_parquet_files()
+            # update paths, limiting by source if set
+            self.paths = timdex_run_manager.get_current_parquet_files(
+                source=filters.get("source")
+            )
+
+            # reload pyarrow dataset
             self._load_pyarrow_dataset()
 
         # filter dataset

--- a/timdex_dataset_api/run.py
+++ b/timdex_dataset_api/run.py
@@ -85,7 +85,22 @@ class TIMDEXRunManager:
         )
         return grouped_runs_df
 
-    def get_current_source_parquet_files(self, source: str) -> list[str]:
+    def get_current_parquet_files(self, source: str | None = None) -> list[str]:
+        """Get reverse chronological list of parquet files associated with current runs.
+
+        Args:
+            source: if provided, limits parquet files to only that source
+        """
+        runs_df = self.get_runs_metadata()  # run metadata is cached for future calls
+        sources = [source] if source else list(runs_df.source.unique())
+
+        source_parquet_files = []
+        for _source in sources:
+            source_parquet_files.extend(self._get_current_source_parquet_files(_source))
+
+        return source_parquet_files
+
+    def _get_current_source_parquet_files(self, source: str) -> list[str]:
         """Get reverse chronological list of current parquet files for a source.
 
         Args:
@@ -114,17 +129,6 @@ class TIMDEXRunManager:
         ordered_parquet_files.extend(last_full_run.parquet_files)
 
         return ordered_parquet_files
-
-    def get_current_parquet_files(self) -> list[str]:
-        """Get reverse chronological list of current parquet files for ALL sources."""
-        runs_df = self.get_runs_metadata()  # run metadata is cached for future calls
-        sources = list(runs_df.source.unique())
-
-        source_parquet_files = []
-        for source in sources:
-            source_parquet_files.extend(self.get_current_source_parquet_files(source))
-
-        return source_parquet_files
 
     def _get_parquet_files_run_metadata(self, max_workers: int = 250) -> pd.DataFrame:
         """Retrieve run metadata from parquet file(s) in dataset.

--- a/timdex_dataset_api/run.py
+++ b/timdex_dataset_api/run.py
@@ -115,6 +115,17 @@ class TIMDEXRunManager:
 
         return ordered_parquet_files
 
+    def get_current_parquet_files(self) -> list[str]:
+        """Get reverse chronological list of current parquet files for ALL sources."""
+        runs_df = self.get_runs_metadata()  # run metadata is cached for future calls
+        sources = list(runs_df.source.unique())
+
+        source_parquet_files = []
+        for source in sources:
+            source_parquet_files.extend(self.get_current_source_parquet_files(source))
+
+        return source_parquet_files
+
     def _get_parquet_files_run_metadata(self, max_workers: int = 250) -> pd.DataFrame:
         """Retrieve run metadata from parquet file(s) in dataset.
 
@@ -166,8 +177,9 @@ class TIMDEXRunManager:
         """
         parquet_file = pq.ParquetFile(
             parquet_filepath,
-            filesystem=self.timdex_dataset.filesystem,  # type: ignore[union-attr]
+            filesystem=self.timdex_dataset.filesystem,
         )
+
         file_meta = parquet_file.metadata.to_dict()
         num_rows = file_meta["num_rows"]
         columns_meta = file_meta["row_groups"][0]["columns"]  # type: ignore[typeddict-item]


### PR DESCRIPTION
### Purpose and background context

This PR marks a somewhat important milestone in this library: support for reading only "current" records from the parquet dataset in a performant and memory-efficient manner.

This builds on PR #143, which introduced the `TIMDEXRunManager` which provided explicit lists of parquet files based on run ETL metadata.  With that in hand, `TIMDEXDataset` was updated in two key ways.

First, the `.load()` method was updated to include a `current_records:bool` keyword argument, which when True, will utilize the `TIMDEXRunManager` to set an explicit list of parquet files for any future reading.

Second, when `current_records` are requested a private attribute is set `TIMDEXDataset._dedupe_on_read = True`.  This informs _all_ read methods to perform record deduping on read, which they can confidently and easily do with the dataset parquet files explicitly set in reverse chronological order.

The majority of the work was not getting this functional, but keeping the API minimal, intuitive, and non-surprising where possible.  For example, to read only current `dspace` records from the dataset, only the following is required:

```python
from timdex_dataset_api import TIMDEXDataset

timdex_dataset = TIMDEXDataset("s3://bucket/dataset")
timdex_dataset.load(current_records=True, source="dspace")

# from here, all read methods will produce only current records
```

The first anticipated use case is for TIM, where a new CLI command along the lines of `reindex-source` would utilize this new `.load()` + read technique to yield  _all and only current_ records for a source purely from dataset data.  No re-harvests would be required.  This is useful for development work, and could be a very useful option in disaster recovery situations.

### How can a reviewer manually see the effects of these changes?

1- Set **Dev Admin** AWS credentials

2- Set following env vars (if not already):
```shell
TDA_LOG_LEVEL=DEBUG
WARNING_ONLY_LOGGERS=asyncio,botocore,urllib3,s3transfer,boto3
```

3- Start Ipython
```shell
pipenv run shell
```

4- Load the dataset for `libguides` current records only
```python
from timdex_dataset_api import TIMDEXDataset
from timdex_dataset_api.config import configure_dev_logger

configure_dev_logger()

timdex_dataset = TIMDEXDataset("s3://ghukill-test/timdex-dataset/prod_2025_05_05")
timdex_dataset.load(current_records=True, source="libguides")
```
- Note some logging outputs that indicate the dataset is loaded and filtered

5- Given the small number of records for this source, load them all into a dataframe (takes ~5 seconds):
```python
df = timdex_dataset.read_dataframe()
```

6- Inspecting the dataframe to confirm that `timdex_record_id` is unique:
```python
df.timdex_record_id.is_unique
# Out[3]: True
```

7- Observe the ETL runs present in the records:
```python
df[['run_date','run_type','run_id']].value_counts()
```
- The count is effectively how many records from that run are "current" (i.e. no new versions after that)
- Note the single `run_type="full"` has the bulk of the records, and `run_type="daily"` runs are just incrementally updating

8- Lastly, optional and just for kicks, an more full fledged example showing looping through all current records for `dspace`:

```python
import time

from timdex_dataset_api import TIMDEXDataset
from timdex_dataset_api.config import configure_dev_logger

configure_dev_logger()

timdex_dataset = TIMDEXDataset("s3://ghukill-test/timdex-dataset/prod_2025_05_05")
timdex_dataset.load(current_records=True, source="dspace")

read_columns = ["timdex_record_id", "run_date", "action", "run_id"]
t0 = time.perf_counter()
count = 0
t1 = time.perf_counter()
for i, batch in enumerate(timdex_dataset.read_batches_iter(columns=read_columns)):
    df = batch.to_pandas()
    row = df.iloc[0]
    count += len(batch)
    print(
        f"batch {i}, rows {len(batch)}, total {count}, run_date {row.run_date}, "
        f"run_id {row.run_id}, elapsed {time.perf_counter() - t1}"
    )
    t1 = time.perf_counter()
print(f"total: {time.perf_counter()-t0}")
```
- Note the batches start with small numbers of records, just updates, until you finally get to the first `run_type="full"` where you get lots of records
- If you have resource monitoring open with something like `btop`, note that memory usage remains low

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: applications like TIM may utilize new TDA functionality to read only current records

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-493
- https://mitlibraries.atlassian.net/browse/TIMX-494

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

