### PR TITLE
TIMX 496 - Add run_timestamp column to dataset

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,6 +25,7 @@ pytest = "*"
 ruff = "*"
 setuptools = "*"
 pip-audit = "*"
+pytest-freezegun = "*"
 
 [requires]
 python_version = "3.12"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "854bdf16b1daf2b669f2c02eb238255d34adb44c7bf55883728f8fdf9910506e"
+            "sha256": "0e54ac5f2ab27e8554d721997de0ab3326821c01a37b269067f3249aa04f694f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -789,6 +789,14 @@
             "markers": "python_version >= '3.9'",
             "version": "==3.18.0"
         },
+        "freezegun": {
+            "hashes": [
+                "sha256:b29dedfcda6d5e8e083ce71b2b542753ad48cfec44037b3fc79702e2980a89e9",
+                "sha256:bf111d7138a8abe55ab48a71755673dbaa4ab87f4cff5634a4442dfec34c15f1"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.5.1"
+        },
         "identify": {
             "hashes": [
                 "sha256:45e92fd704f3da71cc3880036633f48b4b7265fd4de2b57627cb157216eb7eb8",
@@ -1395,6 +1403,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==8.3.5"
+        },
+        "pytest-freezegun": {
+            "hashes": [
+                "sha256:19c82d5633751bf3ec92caa481fb5cffaac1787bd485f0df6436fd6242176949",
+                "sha256:5318a6bfb8ba4b709c8471c94d0033113877b3ee02da5bfcd917c1889cde99a7"
+            ],
+            "index": "pypi",
+            "version": "==0.4.2"
         },
         "pytest-mock": {
             "hashes": [

--- a/timdex_dataset_api/run.py
+++ b/timdex_dataset_api/run.py
@@ -52,6 +52,7 @@ class TIMDEXRunManager:
                     "source": "first",
                     "run_date": "first",
                     "run_type": "first",
+                    "run_timestamp": "first",
                     "num_rows": "sum",
                     "filename": list,
                 }
@@ -65,9 +66,9 @@ class TIMDEXRunManager:
             lambda x: len(x)
         )
 
-        # sort by run date and source
+        # sort by run_timestamp (more granularity than run_date) and source
         grouped_runs_df = grouped_runs_df.sort_values(
-            ["run_date", "source"], ascending=False
+            ["run_timestamp", "source"], ascending=False
         )
 
         # cache the result
@@ -185,12 +186,14 @@ class TIMDEXRunManager:
         run_date = columns_meta[4]["statistics"]["max"]
         run_type = columns_meta[5]["statistics"]["max"]
         run_id = columns_meta[7]["statistics"]["max"]
+        run_timestamp = columns_meta[9]["statistics"]["max"]
 
         return {
             "source": source,
             "run_date": run_date,
             "run_type": run_type,
             "run_id": run_id,
+            "run_timestamp": run_timestamp,
             "num_rows": num_rows,
             "filename": parquet_filepath,
         }


### PR DESCRIPTION
### Purpose and background context

#### 1- TDA Library Code Changes
During work on yielding only "current" records from the dataset, where ordering of the ETL runs in the dataset is critical, it was determined that more time granularity was needed for each ETL run.

Currently we store the `YYYY-MM-DD` for each run in the `run_date` column, but if multiple runs occur on the same day, we are unable to order them more granularly from this alone.

How this addresses that need:
* Adds new `run_timestamp` to parquet dataset schema
* Timestamp is minted before any runs are written, and then used for each row in the ETL run

#### 2- Bulk data work

In addition to this code change, we will need to retroactively add a `run_timestamp` to all past ETL runs in the parquet dataset.  A python script with onetime code that will be used.   This code won't be committed to this repository -- unless it makes sense to build some kind of bulk editing utility into this library? -- but will be shared with the team for input before running.

The flow can be summarized as the following:
- invoke the script with a CSV of limited explicit `run_timestamp`'s for specific `run_id`'s
- for each ETL run (parquet file(s)) in the dataset
~~- if the `run_id` is not included in the input  CSV, set a `run_timestamp` of `YYYY-MM-DD 12:00:01:0000`; one second after midnight~~
~~- if the `run_id` _is_ included in the input CSV, use the explicit `run_timestamp` provided~~
- use the `run_timestamp` from the CSV for the `run_id` associated with the parquet file

An interesting quality of parquet datasets is that "atomic updates" (i.e. adding a new column + value for rows) is not something well supported.  So this script will effectively **rewrite** the dataset, parquet file-by-file, to introduce this new column.  The upside to this work is establishing some experience and workflows for performing such a bulk update.  

The production parquet dataset has ~~roughly 400+ parquet files, probably around 10gb total data~~ ~597 parquet files @ 10gb.  But an interesting dimension here is that most files in the dataset are static and not touched after an ETL run.  So we could theoretically be writing these updated files to the dataset even while ETL runs (with the new code + column!) are occurring.  Which is all to say, actually performing this work shouldn't require much of any coordination.

#### 3- Order of work

- PR code review + merge
- Rebuild TIMDEX terraform in Dev, Stage, Prod to pickup TDA library changes
- Any ETL runs after that will begin writing the `run_timestamp` columnt to new parquet files
- Backup the production parquet dataset
- Run bulk update script that updates only parquet files _without_ `run_timestamp`

A strength of parquet datasets is schema evolution, meaning there is nothing inherently wrong with some parquet files missing a column.  Any **writes** after the code goes live will include this new column, but all **reads** are not expecting or using it yet so it's okay if older files are missing it.  This means we are not rushed to run our bulk update script.

### How can a reviewer manually see the effects of these changes?

0- Set env vars:
```shell
TDA_LOG_LEVEL=DEBUG
WARNING_ONLY_LOGGERS=asyncio,botocore,urllib3,s3transfer,boto3
```

1- Open Ipython shell
```shell
pipenv run ipython
```

2- Perform two "full" writes that occur on the same day `2025-01-01`:
```python
import os
import time

from timdex_dataset_api import TIMDEXDataset
from timdex_dataset_api.config import configure_dev_logger
from tests.utils import generate_sample_records

configure_dev_logger()

LOCATION = "output/datasets/dataset_with_same_day_runs"

if not os.path.exists(LOCATION):
    os.mkdir(LOCATION)

timdex_dataset = TIMDEXDataset(LOCATION)

# Simulate two "full" runs from the same day, where "run-2" is chronologically more recent.
run_params = [
    (100, "alma", "2025-01-01", "full", "index", "run-1"),
    (75, "alma", "2025-01-01", "full", "index", "run-2"),
]
for params in run_params:
    num_records, source, run_date, run_type, action, run_id = params
    records = generate_sample_records(
        num_records,
        timdex_record_id_prefix=source,
        source=source,
        run_date=run_date,
        run_type=run_type,
        action=action,
        run_id=run_id,
    )
    timdex_dataset.write(records)
    time.sleep(5)  # 5 second sleep for observable delay in run_timestamp

# reload after writes
timdex_dataset.load()
```

After these writes, we can see two parquet files under the same day partitions:
```
output/datasets/dataset_with_same_day_runs
└── year=2025
    └── month=01
        └── day=01
            ├── a4556d0b-853c-47f9-a525-1241c3306f93-0.parquet
            └── eee646a1-3e98-4434-a2ee-2bc8e3568a1c-0.parquet
```

3- Load a dataframe with all rows and inspect new `run_timestamp` column values:
```python
df = timdex_dataset.read_dataframe()

df[['run_date','run_id','run_timestamp']].value_counts()
"""
Out[3]: 
run_date    run_id  run_timestamp                   
2025-01-01  run-1   2025-05-29 14:39:20.016089+00:00    100
            run-2   2025-05-29 14:39:25.026558+00:00     75
Name: count, dtype: int64
"""
```
- note that all rows for each run have a single `run_timestamp` value
- note that `run-2` is 5 seconds after `run-1`
- note that `run_timestamp` has **microsecond** accuracy, which should be more than sufficient for even virtually simultaneous ETL runs

4- Lastly, utilize `load(current_records=True)` to see that `run_timestamp` is utilized to correctly to only get `run-2` records given it's the most recent "full" run:
```python
timdex_dataset.load(current_records=True)
df_current = timdex_dataset.read_dataframe()
df_current.run_id.value_counts()
"""
Out[4]: 
run_id
run-2    75   <-----------------
Name: count, dtype: int64
"""
```

### Includes new or updated dependencies?
YES

### Changes expectations for external applications?
YES: All TIMDEX components that use this library for reading and writing will need a terraform rebuild to pick up this change.  Otherwise, they need no further modification.

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-496

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

