### PR TITLE
TIMX 506 - new dataset metadata client

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -27,20 +27,20 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0fe6b7d1974851588ec1edd39c66d9525d539133e02c7f985f9ebec5e222c0db",
-                "sha256:6f4163cd9e030afd1059e8a6daa178835165b79eb0b5325a8cd447020b895921"
+                "sha256:2cb783c668ae4f2a86b6497b47251b9baf9a16db8fff863b57eae683276b9e1f",
+                "sha256:a9b4c7021bf5adee985523fc87db27a7200de161c094cb8f709b93a81797dc8a"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.38"
+            "version": "==1.38.42"
         },
         "botocore": {
             "hashes": [
-                "sha256:aa5cc63bf885819d862852edb647d6276fe423c60113e8db375bb7ad8d88a5d9",
-                "sha256:acf9ae5b2d99c1f416f94fa5b4f8c044ecb76ffcb7fb1b1daec583f36892a8e2"
+                "sha256:3a14188e48f6e26be561164373d34150fa9cb39f7ad32cc745dcd3ab05f43683",
+                "sha256:fbbeac30c045b5c19f1c3bb063ea2b6315ce2d6fcb3d898e87d1c1846297961c"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.38"
+            "version": "==1.38.42"
         },
         "duckdb": {
             "hashes": [
@@ -95,60 +95,60 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:06d4fb37a8d383b769281714897420c5cc3545c79dc427df57fc9b852ee0bf58",
-                "sha256:0898c67a58cdaaf29994bc0e2c65230fd4de0ac40afaf1584ed0b02cd74c6fdd",
-                "sha256:0eba4a1ea88f9a6f30f56fdafdeb8da3774349eacddab9581a21234b8535d3d3",
-                "sha256:2393a914db64b0ead0ab80c962e42d09d5f385802006a6c87835acb1f58adb96",
-                "sha256:2e6a1409eee0cb0316cb64640a49a49ca44deb1a537e6b1121dc7c458a1299a8",
-                "sha256:33a5a12a45bb82d9997e2c0b12adae97507ad7c347546190a18ff14c28bbca12",
-                "sha256:389b85335838155a9076e9ad7f8fdba0827496ec2d2dc32ce69ce7898bde03ba",
-                "sha256:39b27d8b38942a647f048b675f134dd5a567f95bfff481f9109ec308515c51d8",
-                "sha256:43c55b6a860b0eb44d42341438b03513cf3879cb3617afb749ad49307e164edd",
-                "sha256:46d16f72c2192da7b83984aa5455baee640e33a9f1e61e656f29adf55e406c2b",
-                "sha256:48a2e8eaf76364c32a1feaa60d6925eaf32ed7a040183b807e02674305beef61",
-                "sha256:4d8d294287fdf685281e671886c6dcdf0291a7c19db3e5cb4178d07ccf6ecc67",
-                "sha256:4dc58865623023b63b10d52f18abaac3729346a7a46a778381e0e3af4b7f3beb",
-                "sha256:50080245365d75137a2bf46151e975de63146ae6d79f7e6bd5c0e85c9931d06a",
-                "sha256:54dfc8681c1906d239e95ab1508d0a533c4a9505e52ee2d71a5472b04437ef97",
-                "sha256:5754ab5595bfa2c2387d241296e0381c21f44a4b90a776c3c1d39eede13a746a",
-                "sha256:5814a0f43e70c061f47abd5857d120179609ddc32a613138cbb6c4e9e2dbdda5",
-                "sha256:581f87f9e9e9db2cba2141400e160e9dd644ee248788d6f90636eeb8fd9260a6",
-                "sha256:622a65d40d8eb427d8e722fd410ac3ad4958002f109230bc714fa551044ebae2",
-                "sha256:6295f81f093b7f5769d1728a6bd8bf7466de2adfa771ede944ce6711382b89dc",
-                "sha256:690d0a5b60a47e1f9dcec7b77750a4854c0d690e9058b7bef3106e3ae9117808",
-                "sha256:7729c8008d55e80784bd113787ce876ca117185c579c0d626f59b87d433ea779",
-                "sha256:80b46117c7359de8167cc00a2c7d823bdd505e8c7727ae0871025a86d668283b",
-                "sha256:81ae0bf2564cf475f94be4a27ef7bcf8af0c3e28da46770fc904da9abd5279b5",
-                "sha256:87717eb24d4a8a64683b7a4e91ace04e2f5c7c77872f823f02a94feee186168f",
-                "sha256:8b51ead2b258284458e570942137155978583e407babc22e3d0ed7af33ce06f8",
-                "sha256:9498f60cd6bb8238d8eaf468a3d5bb031d34cd12556af53510f05fcf581c1b7e",
-                "sha256:99224862d1412d2562248d4710126355d3a8db7672170a39d6909ac47687a8a4",
-                "sha256:a0be278be9307c4ab06b788f2a077f05e180aea817b3e41cebbd5aaf7bd85ed3",
-                "sha256:aaf81c7b82c73bd9b45e79cfb9476cb9c29e937494bfe9092c26aece812818ad",
-                "sha256:aba48d17e87688a765ab1cd557882052f238e2f36545dfa8e29e6a91aef77afe",
-                "sha256:b0f1f11d0a1da54927436505a5a7670b154eac27f5672afc389661013dfe3d4f",
-                "sha256:b9446d9d8505aadadb686d51d838f2b6688c9e85636a0c3abaeb55ed54756459",
-                "sha256:ba17f93a94e503551f154de210e4d50c5e3ee20f7e7a1b5f6ce3f22d419b93bb",
-                "sha256:bd8df082b6c4695753ad6193018c05aac465d634834dca47a3ae06d4bb22d9ea",
-                "sha256:c24bb4113c66936eeaa0dc1e47c74770453d34f46ee07ae4efd853a2ed1ad10a",
-                "sha256:c39ec392b5db5088259c68250e342612db82dc80ce044cf16496cf14cf6bc6f8",
-                "sha256:c3c9fdde0fa18afa1099d6257eb82890ea4f3102847e692193b54e00312a9ae9",
-                "sha256:c8738baa52505fa6e82778580b23f945e3578412554d937093eac9205e845e6e",
-                "sha256:d11fa02f77752d8099573d64e5fe33de3229b6632036ec08f7080f46b6649959",
-                "sha256:d344ca32ab482bcf8735d8f95091ad081f97120546f3d250240868430ce52555",
-                "sha256:d8fa264d56882b59dcb5ea4d6ab6f31d0c58a57b41aec605848b6eb2ef4a43e8",
-                "sha256:df470d376f54e052c76517393fa443758fefcdd634645bc9c1f84eafc67087f0",
-                "sha256:e017a8a251ff4d18d71f139e28bdc7c31edba7a507f72b1414ed902cbe48c74d",
-                "sha256:e43c3cce3b6ae5f94696669ff2a6eafd9a6b9332008bafa4117af70f4b88be6f",
-                "sha256:e651756066a0eaf900916497e20e02fe1ae544187cb0fe88de981671ee7f6270",
-                "sha256:e6648078bdd974ef5d15cecc31b0c410e2e24178a6e10bf511e0557eed0f2570",
-                "sha256:ee9d3ee70d62827bc91f3ea5eee33153212c41f639918550ac0475e3588da59f",
-                "sha256:ef6c1e88fd6b81ac6d215ed71dc8cd027e54d4bf1d2682d362449097156267a2",
-                "sha256:f14e016d9409680959691c109be98c436c6249eaf7f118b424679793607b5944",
-                "sha256:f420033a20b4f6a2a11f585f93c843ac40686a7c3fa514060a97d9de93e5e72b"
+                "sha256:0025048b3c1557a20bc80d06fdeb8cc7fc193721484cca82b2cfa072fec71a93",
+                "sha256:010ce9b4f00d5c036053ca684c77441f2f2c934fd23bee058b4d6f196efd8280",
+                "sha256:0bb3a4a61e1d327e035275d2a993c96fa786e4913aa089843e6a2d9dd205c66a",
+                "sha256:0c4d9e0a8368db90f93bd192bfa771ace63137c3488d198ee21dfb8e7771916e",
+                "sha256:15aa4c392ac396e2ad3d0a2680c0f0dee420f9fed14eef09bdb9450ee6dcb7b7",
+                "sha256:18703df6c4a4fee55fd3d6e5a253d01c5d33a295409b03fda0c86b3ca2ff41a1",
+                "sha256:1ec9ae20a4226da374362cca3c62cd753faf2f951440b0e3b98e93c235441d2b",
+                "sha256:23ab05b2d241f76cb883ce8b9a93a680752fbfcbd51c50eff0b88b979e471d8c",
+                "sha256:25a1992b0a3fdcdaec9f552ef10d8103186f5397ab45e2d25f8ac51b1a6b97e8",
+                "sha256:2959d8f268f3d8ee402b04a9ec4bb7604555aeacf78b360dc4ec27f1d508177d",
+                "sha256:2a809637460e88a113e186e87f228d74ae2852a2e0c44de275263376f17b5bdc",
+                "sha256:2fb86b7e58f9ac50e1e9dd1290154107e47d1eef23a0ae9145ded06ea606f992",
+                "sha256:36890eb9e9d2081137bd78d29050ba63b8dab95dff7912eadf1185e80074b2a0",
+                "sha256:39bff12c076812595c3a306f22bfe49919c5513aa1e0e70fac756a0be7c2a2b8",
+                "sha256:467db865b392168ceb1ef1ffa6f5a86e62468c43e0cfb4ab6da667ede10e58db",
+                "sha256:4e602e1b8682c2b833af89ba641ad4176053aaa50f5cacda1a27004352dde943",
+                "sha256:5902660491bd7a48b2ec16c23ccb9124b8abfd9583c5fdfa123fe6b421e03de1",
+                "sha256:5ccb7336eaf0e77c1635b232c141846493a588ec9ea777a7c24d7166bb8533ae",
+                "sha256:5f1b8f26d1086835f442286c1d9b64bb3974b0b1e41bb105358fd07d20872952",
+                "sha256:6269b9edfe32912584ec496d91b00b6d34282ca1d07eb10e82dfc780907d6c2e",
+                "sha256:6ea9e48336a402551f52cd8f593343699003d2353daa4b72ce8d34f66b722070",
+                "sha256:762e0c0c6b56bdedfef9a8e1d4538556438288c4276901ea008ae44091954e29",
+                "sha256:7be91b2239af2658653c5bb6f1b8bccafaf08226a258caf78ce44710a0160d30",
+                "sha256:7dea630156d39b02a63c18f508f85010230409db5b2927ba59c8ba4ab3e8272e",
+                "sha256:867ef172a0976aaa1f1d1b63cf2090de8b636a7674607d514505fb7276ab08fc",
+                "sha256:8d5ee6eec45f08ce507a6570e06f2f879b374a552087a4179ea7838edbcbfa42",
+                "sha256:8e333040d069eba1652fb08962ec5b76af7f2c7bce1df7e1418c8055cf776f25",
+                "sha256:a5ee121b60aa509679b682819c602579e1df14a5b07fe95671c8849aad8f2115",
+                "sha256:a780033466159c2270531e2b8ac063704592a0bc62ec4a1b991c7c40705eb0e8",
+                "sha256:a894f3816eb17b29e4783e5873f92faf55b710c2519e5c351767c51f79d8526d",
+                "sha256:a8b740f5579ae4585831b3cf0e3b0425c667274f82a484866d2adf9570539369",
+                "sha256:ad506d4b09e684394c42c966ec1527f6ebc25da7f4da4b1b056606ffe446b8a3",
+                "sha256:afed2ce4a84f6b0fc6c1ce734ff368cbf5a5e24e8954a338f3bdffa0718adffb",
+                "sha256:b0b5397374f32ec0649dd98c652a1798192042e715df918c20672c62fb52d4b8",
+                "sha256:bada6058dd886061f10ea15f230ccf7dfff40572e99fef440a4a857c8728c9c0",
+                "sha256:c4913079974eeb5c16ccfd2b1f09354b8fed7e0d6f2cab933104a09a6419b1ee",
+                "sha256:c5bdf2015ccfcee8253fb8be695516ac4457c743473a43290fd36eba6a1777eb",
+                "sha256:c6e0bf9d1a2f50d2b65a7cf56db37c095af17b59f6c132396f7c6d5dd76484df",
+                "sha256:ce2ce9e5de4703a673e705183f64fd5da5bf36e7beddcb63a25ee2286e71ca48",
+                "sha256:cfecc7822543abdea6de08758091da655ea2210b8ffa1faf116b940693d3df76",
+                "sha256:d4580adadc53311b163444f877e0789f1c8861e2698f6b2a4ca852fda154f3ff",
+                "sha256:d70f20df7f08b90a2062c1f07737dd340adccf2068d0f1b9b3d56e2038979fee",
+                "sha256:e344eb79dab01f1e838ebb67aab09965fb271d6da6b00adda26328ac27d4a66e",
+                "sha256:e610832418a2bc09d974cc9fecebfa51e9532d6190223bc5ef6a7402ebf3b5cb",
+                "sha256:e772dda20a6002ef7061713dc1e2585bc1b534e7909b2030b5a46dae8ff077ab",
+                "sha256:e7cbf5a5eafd8d230a3ce356d892512185230e4781a361229bd902ff403bc660",
+                "sha256:eabd7e8740d494ce2b4ea0ff05afa1b7b291e978c0ae075487c51e8bd93c0c68",
+                "sha256:ebb8603d45bc86bbd5edb0d63e52c5fd9e7945d3a503b77e486bd88dde67a19b",
+                "sha256:ec0bdafa906f95adc9a0c6f26a4871fa753f25caaa0e032578a30457bff0af6a",
+                "sha256:eccb9a159db9aed60800187bc47a6d3451553f0e1b08b068d8b277ddfbb9b244",
+                "sha256:ee8340cb48c9b7a5899d1149eece41ca535513a9698098edbade2a8e7a84da77"
             ],
             "markers": "python_version >= '3.11'",
-            "version": "==2.3.0"
+            "version": "==2.3.1"
         },
         "pandas": {
             "hashes": [
@@ -302,11 +302,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466",
-                "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"
+                "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760",
+                "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.4.0"
+            "version": "==2.5.0"
         }
     },
     "develop": {
@@ -356,30 +356,30 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0fe6b7d1974851588ec1edd39c66d9525d539133e02c7f985f9ebec5e222c0db",
-                "sha256:6f4163cd9e030afd1059e8a6daa178835165b79eb0b5325a8cd447020b895921"
+                "sha256:2cb783c668ae4f2a86b6497b47251b9baf9a16db8fff863b57eae683276b9e1f",
+                "sha256:a9b4c7021bf5adee985523fc87db27a7200de161c094cb8f709b93a81797dc8a"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.38"
+            "version": "==1.38.42"
         },
         "boto3-stubs": {
             "extras": [
                 "s3"
             ],
             "hashes": [
-                "sha256:4572065010391c5b3ff51129d0ac76f40b35b5ae6f5585bcb1d0454341e97f19",
-                "sha256:7b8ac61e65af3c987e53b438a9741f6de976c43137ec9d78c95067e8fda4df0c"
+                "sha256:28efa210ab1f0399af4ef10fff6f3b3438c0e5111450293200e33920daf545a9",
+                "sha256:9901e3e162fff10580a56fc33634089aa2096ea91256ad157efa835b71b8ebc1"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.38.38"
+            "version": "==1.38.42"
         },
         "botocore": {
             "hashes": [
-                "sha256:aa5cc63bf885819d862852edb647d6276fe423c60113e8db375bb7ad8d88a5d9",
-                "sha256:acf9ae5b2d99c1f416f94fa5b4f8c044ecb76ffcb7fb1b1daec583f36892a8e2"
+                "sha256:3a14188e48f6e26be561164373d34150fa9cb39f7ad32cc745dcd3ab05f43683",
+                "sha256:fbbeac30c045b5c19f1c3bb063ea2b6315ce2d6fcb3d898e87d1c1846297961c"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.38"
+            "version": "==1.38.42"
         },
         "botocore-stubs": {
             "hashes": [
@@ -1055,11 +1055,11 @@
         },
         "mypy-boto3-s3": {
             "hashes": [
-                "sha256:1129d64be1aee863e04f0c92ac8d315578f13ccae64fa199b20ad0950d2b9616",
-                "sha256:38a45dee5782d5c07ddea07ea50965c4d2ba7e77617c19f613b4c9f80f961b52"
+                "sha256:9b003a3d4f4e01c6f3a7dc01e6bdcf9cc58e74c48cfbccd7cf80328b5b3ef4c7",
+                "sha256:b272d1c9b359017ea7c5d79b4610ba93e91f557ad01da0d6e302bd7b7804f73b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.38.26"
+            "version": "==1.38.39"
         },
         "mypy-extensions": {
             "hashes": [
@@ -1079,60 +1079,60 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:06d4fb37a8d383b769281714897420c5cc3545c79dc427df57fc9b852ee0bf58",
-                "sha256:0898c67a58cdaaf29994bc0e2c65230fd4de0ac40afaf1584ed0b02cd74c6fdd",
-                "sha256:0eba4a1ea88f9a6f30f56fdafdeb8da3774349eacddab9581a21234b8535d3d3",
-                "sha256:2393a914db64b0ead0ab80c962e42d09d5f385802006a6c87835acb1f58adb96",
-                "sha256:2e6a1409eee0cb0316cb64640a49a49ca44deb1a537e6b1121dc7c458a1299a8",
-                "sha256:33a5a12a45bb82d9997e2c0b12adae97507ad7c347546190a18ff14c28bbca12",
-                "sha256:389b85335838155a9076e9ad7f8fdba0827496ec2d2dc32ce69ce7898bde03ba",
-                "sha256:39b27d8b38942a647f048b675f134dd5a567f95bfff481f9109ec308515c51d8",
-                "sha256:43c55b6a860b0eb44d42341438b03513cf3879cb3617afb749ad49307e164edd",
-                "sha256:46d16f72c2192da7b83984aa5455baee640e33a9f1e61e656f29adf55e406c2b",
-                "sha256:48a2e8eaf76364c32a1feaa60d6925eaf32ed7a040183b807e02674305beef61",
-                "sha256:4d8d294287fdf685281e671886c6dcdf0291a7c19db3e5cb4178d07ccf6ecc67",
-                "sha256:4dc58865623023b63b10d52f18abaac3729346a7a46a778381e0e3af4b7f3beb",
-                "sha256:50080245365d75137a2bf46151e975de63146ae6d79f7e6bd5c0e85c9931d06a",
-                "sha256:54dfc8681c1906d239e95ab1508d0a533c4a9505e52ee2d71a5472b04437ef97",
-                "sha256:5754ab5595bfa2c2387d241296e0381c21f44a4b90a776c3c1d39eede13a746a",
-                "sha256:5814a0f43e70c061f47abd5857d120179609ddc32a613138cbb6c4e9e2dbdda5",
-                "sha256:581f87f9e9e9db2cba2141400e160e9dd644ee248788d6f90636eeb8fd9260a6",
-                "sha256:622a65d40d8eb427d8e722fd410ac3ad4958002f109230bc714fa551044ebae2",
-                "sha256:6295f81f093b7f5769d1728a6bd8bf7466de2adfa771ede944ce6711382b89dc",
-                "sha256:690d0a5b60a47e1f9dcec7b77750a4854c0d690e9058b7bef3106e3ae9117808",
-                "sha256:7729c8008d55e80784bd113787ce876ca117185c579c0d626f59b87d433ea779",
-                "sha256:80b46117c7359de8167cc00a2c7d823bdd505e8c7727ae0871025a86d668283b",
-                "sha256:81ae0bf2564cf475f94be4a27ef7bcf8af0c3e28da46770fc904da9abd5279b5",
-                "sha256:87717eb24d4a8a64683b7a4e91ace04e2f5c7c77872f823f02a94feee186168f",
-                "sha256:8b51ead2b258284458e570942137155978583e407babc22e3d0ed7af33ce06f8",
-                "sha256:9498f60cd6bb8238d8eaf468a3d5bb031d34cd12556af53510f05fcf581c1b7e",
-                "sha256:99224862d1412d2562248d4710126355d3a8db7672170a39d6909ac47687a8a4",
-                "sha256:a0be278be9307c4ab06b788f2a077f05e180aea817b3e41cebbd5aaf7bd85ed3",
-                "sha256:aaf81c7b82c73bd9b45e79cfb9476cb9c29e937494bfe9092c26aece812818ad",
-                "sha256:aba48d17e87688a765ab1cd557882052f238e2f36545dfa8e29e6a91aef77afe",
-                "sha256:b0f1f11d0a1da54927436505a5a7670b154eac27f5672afc389661013dfe3d4f",
-                "sha256:b9446d9d8505aadadb686d51d838f2b6688c9e85636a0c3abaeb55ed54756459",
-                "sha256:ba17f93a94e503551f154de210e4d50c5e3ee20f7e7a1b5f6ce3f22d419b93bb",
-                "sha256:bd8df082b6c4695753ad6193018c05aac465d634834dca47a3ae06d4bb22d9ea",
-                "sha256:c24bb4113c66936eeaa0dc1e47c74770453d34f46ee07ae4efd853a2ed1ad10a",
-                "sha256:c39ec392b5db5088259c68250e342612db82dc80ce044cf16496cf14cf6bc6f8",
-                "sha256:c3c9fdde0fa18afa1099d6257eb82890ea4f3102847e692193b54e00312a9ae9",
-                "sha256:c8738baa52505fa6e82778580b23f945e3578412554d937093eac9205e845e6e",
-                "sha256:d11fa02f77752d8099573d64e5fe33de3229b6632036ec08f7080f46b6649959",
-                "sha256:d344ca32ab482bcf8735d8f95091ad081f97120546f3d250240868430ce52555",
-                "sha256:d8fa264d56882b59dcb5ea4d6ab6f31d0c58a57b41aec605848b6eb2ef4a43e8",
-                "sha256:df470d376f54e052c76517393fa443758fefcdd634645bc9c1f84eafc67087f0",
-                "sha256:e017a8a251ff4d18d71f139e28bdc7c31edba7a507f72b1414ed902cbe48c74d",
-                "sha256:e43c3cce3b6ae5f94696669ff2a6eafd9a6b9332008bafa4117af70f4b88be6f",
-                "sha256:e651756066a0eaf900916497e20e02fe1ae544187cb0fe88de981671ee7f6270",
-                "sha256:e6648078bdd974ef5d15cecc31b0c410e2e24178a6e10bf511e0557eed0f2570",
-                "sha256:ee9d3ee70d62827bc91f3ea5eee33153212c41f639918550ac0475e3588da59f",
-                "sha256:ef6c1e88fd6b81ac6d215ed71dc8cd027e54d4bf1d2682d362449097156267a2",
-                "sha256:f14e016d9409680959691c109be98c436c6249eaf7f118b424679793607b5944",
-                "sha256:f420033a20b4f6a2a11f585f93c843ac40686a7c3fa514060a97d9de93e5e72b"
+                "sha256:0025048b3c1557a20bc80d06fdeb8cc7fc193721484cca82b2cfa072fec71a93",
+                "sha256:010ce9b4f00d5c036053ca684c77441f2f2c934fd23bee058b4d6f196efd8280",
+                "sha256:0bb3a4a61e1d327e035275d2a993c96fa786e4913aa089843e6a2d9dd205c66a",
+                "sha256:0c4d9e0a8368db90f93bd192bfa771ace63137c3488d198ee21dfb8e7771916e",
+                "sha256:15aa4c392ac396e2ad3d0a2680c0f0dee420f9fed14eef09bdb9450ee6dcb7b7",
+                "sha256:18703df6c4a4fee55fd3d6e5a253d01c5d33a295409b03fda0c86b3ca2ff41a1",
+                "sha256:1ec9ae20a4226da374362cca3c62cd753faf2f951440b0e3b98e93c235441d2b",
+                "sha256:23ab05b2d241f76cb883ce8b9a93a680752fbfcbd51c50eff0b88b979e471d8c",
+                "sha256:25a1992b0a3fdcdaec9f552ef10d8103186f5397ab45e2d25f8ac51b1a6b97e8",
+                "sha256:2959d8f268f3d8ee402b04a9ec4bb7604555aeacf78b360dc4ec27f1d508177d",
+                "sha256:2a809637460e88a113e186e87f228d74ae2852a2e0c44de275263376f17b5bdc",
+                "sha256:2fb86b7e58f9ac50e1e9dd1290154107e47d1eef23a0ae9145ded06ea606f992",
+                "sha256:36890eb9e9d2081137bd78d29050ba63b8dab95dff7912eadf1185e80074b2a0",
+                "sha256:39bff12c076812595c3a306f22bfe49919c5513aa1e0e70fac756a0be7c2a2b8",
+                "sha256:467db865b392168ceb1ef1ffa6f5a86e62468c43e0cfb4ab6da667ede10e58db",
+                "sha256:4e602e1b8682c2b833af89ba641ad4176053aaa50f5cacda1a27004352dde943",
+                "sha256:5902660491bd7a48b2ec16c23ccb9124b8abfd9583c5fdfa123fe6b421e03de1",
+                "sha256:5ccb7336eaf0e77c1635b232c141846493a588ec9ea777a7c24d7166bb8533ae",
+                "sha256:5f1b8f26d1086835f442286c1d9b64bb3974b0b1e41bb105358fd07d20872952",
+                "sha256:6269b9edfe32912584ec496d91b00b6d34282ca1d07eb10e82dfc780907d6c2e",
+                "sha256:6ea9e48336a402551f52cd8f593343699003d2353daa4b72ce8d34f66b722070",
+                "sha256:762e0c0c6b56bdedfef9a8e1d4538556438288c4276901ea008ae44091954e29",
+                "sha256:7be91b2239af2658653c5bb6f1b8bccafaf08226a258caf78ce44710a0160d30",
+                "sha256:7dea630156d39b02a63c18f508f85010230409db5b2927ba59c8ba4ab3e8272e",
+                "sha256:867ef172a0976aaa1f1d1b63cf2090de8b636a7674607d514505fb7276ab08fc",
+                "sha256:8d5ee6eec45f08ce507a6570e06f2f879b374a552087a4179ea7838edbcbfa42",
+                "sha256:8e333040d069eba1652fb08962ec5b76af7f2c7bce1df7e1418c8055cf776f25",
+                "sha256:a5ee121b60aa509679b682819c602579e1df14a5b07fe95671c8849aad8f2115",
+                "sha256:a780033466159c2270531e2b8ac063704592a0bc62ec4a1b991c7c40705eb0e8",
+                "sha256:a894f3816eb17b29e4783e5873f92faf55b710c2519e5c351767c51f79d8526d",
+                "sha256:a8b740f5579ae4585831b3cf0e3b0425c667274f82a484866d2adf9570539369",
+                "sha256:ad506d4b09e684394c42c966ec1527f6ebc25da7f4da4b1b056606ffe446b8a3",
+                "sha256:afed2ce4a84f6b0fc6c1ce734ff368cbf5a5e24e8954a338f3bdffa0718adffb",
+                "sha256:b0b5397374f32ec0649dd98c652a1798192042e715df918c20672c62fb52d4b8",
+                "sha256:bada6058dd886061f10ea15f230ccf7dfff40572e99fef440a4a857c8728c9c0",
+                "sha256:c4913079974eeb5c16ccfd2b1f09354b8fed7e0d6f2cab933104a09a6419b1ee",
+                "sha256:c5bdf2015ccfcee8253fb8be695516ac4457c743473a43290fd36eba6a1777eb",
+                "sha256:c6e0bf9d1a2f50d2b65a7cf56db37c095af17b59f6c132396f7c6d5dd76484df",
+                "sha256:ce2ce9e5de4703a673e705183f64fd5da5bf36e7beddcb63a25ee2286e71ca48",
+                "sha256:cfecc7822543abdea6de08758091da655ea2210b8ffa1faf116b940693d3df76",
+                "sha256:d4580adadc53311b163444f877e0789f1c8861e2698f6b2a4ca852fda154f3ff",
+                "sha256:d70f20df7f08b90a2062c1f07737dd340adccf2068d0f1b9b3d56e2038979fee",
+                "sha256:e344eb79dab01f1e838ebb67aab09965fb271d6da6b00adda26328ac27d4a66e",
+                "sha256:e610832418a2bc09d974cc9fecebfa51e9532d6190223bc5ef6a7402ebf3b5cb",
+                "sha256:e772dda20a6002ef7061713dc1e2585bc1b534e7909b2030b5a46dae8ff077ab",
+                "sha256:e7cbf5a5eafd8d230a3ce356d892512185230e4781a361229bd902ff403bc660",
+                "sha256:eabd7e8740d494ce2b4ea0ff05afa1b7b291e978c0ae075487c51e8bd93c0c68",
+                "sha256:ebb8603d45bc86bbd5edb0d63e52c5fd9e7945d3a503b77e486bd88dde67a19b",
+                "sha256:ec0bdafa906f95adc9a0c6f26a4871fa753f25caaa0e032578a30457bff0af6a",
+                "sha256:eccb9a159db9aed60800187bc47a6d3451553f0e1b08b068d8b277ddfbb9b244",
+                "sha256:ee8340cb48c9b7a5899d1149eece41ca535513a9698098edbade2a8e7a84da77"
             ],
             "markers": "python_version >= '3.11'",
-            "version": "==2.3.0"
+            "version": "==2.3.1"
         },
         "packageurl-python": {
             "hashes": [
@@ -1334,12 +1334,12 @@
         },
         "pyarrow-stubs": {
             "hashes": [
-                "sha256:58c983b68e63a07133741b48edfad85a4fb61bf227fda890c01850868dbfe560",
-                "sha256:d20b4a04a31e3d93240c057e7a8259587b5dc6db24f8b507f9eac1b209d9ba0c"
+                "sha256:34edc92af48e0123c223526d61ed76932a2bd214329c771dfcbb2e5aa1fb820d",
+                "sha256:ba41fa49e3f2516be492df7fa2976a4ddf333f5255e5ced28b116a5db9480c3d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9' and python_version < '4'",
-            "version": "==19.4"
+            "version": "==20.0.0.20250618"
         },
         "pycparser": {
             "hashes": [
@@ -1351,11 +1351,11 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f",
-                "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"
+                "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887",
+                "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.19.1"
+            "version": "==2.19.2"
         },
         "pyparsing": {
             "hashes": [
@@ -1367,12 +1367,12 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6",
-                "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e"
+                "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7",
+                "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==8.4.0"
+            "version": "==8.4.1"
         },
         "pytest-mock": {
             "hashes": [
@@ -1588,11 +1588,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466",
-                "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"
+                "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760",
+                "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.4.0"
+            "version": "==2.5.0"
         },
         "virtualenv": {
             "hashes": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from tests.utils import (
     generate_sample_records,
     generate_sample_records_with_simulated_partitions,
 )
-from timdex_dataset_api import TIMDEXDataset
+from timdex_dataset_api import TIMDEXDataset, TIMDEXDatasetMetadata
 from timdex_dataset_api.dataset import TIMDEXDatasetConfig
 
 
@@ -208,3 +208,8 @@ def dataset_with_same_day_runs(tmp_path) -> TIMDEXDataset:
     timdex_dataset.load()
 
     return timdex_dataset
+
+
+@pytest.fixture
+def timdex_dataset_metadata(dataset_with_same_day_runs):
+    return TIMDEXDatasetMetadata(timdex_dataset=dataset_with_same_day_runs)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,89 @@
+# ruff: noqa: PLR2004
+
+import duckdb
+
+from timdex_dataset_api import TIMDEXDataset, TIMDEXDatasetMetadata
+
+
+def test_tdm_init_from_timdex_dataset_instance_success(dataset_with_same_day_runs):
+    tdm = TIMDEXDatasetMetadata(timdex_dataset=dataset_with_same_day_runs)
+    assert isinstance(tdm.timdex_dataset, TIMDEXDataset)
+
+
+def test_tdm_init_from_timdex_dataset_path_success(dataset_with_runs_location):
+    tdm = TIMDEXDatasetMetadata.from_dataset_location(dataset_with_runs_location)
+    assert isinstance(tdm.timdex_dataset, TIMDEXDataset)
+
+
+def test_tdm_default_database_location_in_memory(timdex_dataset_metadata):
+    assert timdex_dataset_metadata.db_path == ":memory:"
+    result = timdex_dataset_metadata.conn.query("PRAGMA database_list;").fetchone()
+    assert result[1] == "memory"  # name of database
+    assert result[2] is None  # file associated with database, where None is memory
+
+
+def test_tdm_explicit_database_in_file(tmp_path, dataset_with_runs_location):
+    db_path = str(tmp_path / "tda.duckdb")
+    tdm = TIMDEXDatasetMetadata.from_dataset_location(
+        dataset_with_runs_location,
+        db_path=db_path,
+    )
+    assert tdm.db_path == db_path
+    result = tdm.conn.query("PRAGMA database_list;").fetchone()
+    assert result[1] == "tda"  # name of database
+    assert result[2] == db_path  # filepath passed during init
+
+
+def test_tdm_get_duckdb_connection(timdex_dataset_metadata):
+    conn = timdex_dataset_metadata.get_connection()
+    assert isinstance(conn, duckdb.DuckDBPyConnection)
+
+
+def test_tdm_set_threads(timdex_dataset_metadata):
+    # set to 64
+    timdex_dataset_metadata.set_database_thread_usage(64)
+    sixty_four_thread_count = timdex_dataset_metadata.conn.query(
+        """SELECT current_setting('threads');"""
+    ).fetchone()[0]
+    assert sixty_four_thread_count == 64
+
+    # set to 12
+    timdex_dataset_metadata.set_database_thread_usage(12)
+    sixty_four_thread_count = timdex_dataset_metadata.conn.query(
+        """SELECT current_setting('threads');"""
+    ).fetchone()[0]
+    assert sixty_four_thread_count == 12
+
+
+def test_tdm_init_sets_up_database(timdex_dataset_metadata):
+    df = timdex_dataset_metadata.conn.query("show tables;").to_df()
+    assert set(df.name) == {"current_records", "records"}
+
+
+def test_tdm_get_current_parquet_files(timdex_dataset_metadata):
+    parquet_files = timdex_dataset_metadata.get_current_parquet_files()
+    # assert 5 total parquet files in dataset
+    # but only 3 contain current records
+    assert len(timdex_dataset_metadata.timdex_dataset.dataset.files) == 5
+    assert len(parquet_files) == 3
+
+
+def test_tdm_get_record_to_run_mapping(timdex_dataset_metadata):
+    record_map = timdex_dataset_metadata.get_current_record_to_run_map()
+
+    assert len(record_map) == 75
+    assert record_map["alma:0"] == "run-5"
+    assert record_map["alma:5"] == "run-4"
+    assert record_map["alma:19"] == "run-4"
+    assert "run-3" not in record_map.values()
+    assert record_map["alma:20"] == "run-2"
+
+
+def test_tdm_current_records_subset_of_all_records(timdex_dataset_metadata):
+    records_df = timdex_dataset_metadata.conn.query("select * from records;").to_df()
+    current_records_df = timdex_dataset_metadata.conn.query(
+        "select * from current_records;"
+    ).to_df()
+    assert set(current_records_df.timdex_record_id).issubset(
+        set(records_df.timdex_record_id)
+    )

--- a/timdex_dataset_api/__init__.py
+++ b/timdex_dataset_api/__init__.py
@@ -1,6 +1,7 @@
 """timdex_dataset_api/__init__.py"""
 
 from timdex_dataset_api.dataset import TIMDEXDataset
+from timdex_dataset_api.metadata import TIMDEXDatasetMetadata
 from timdex_dataset_api.record import DatasetRecord
 
 __version__ = "2.1.0"
@@ -8,4 +9,5 @@ __version__ = "2.1.0"
 __all__ = [
     "DatasetRecord",
     "TIMDEXDataset",
+    "TIMDEXDatasetMetadata",
 ]

--- a/timdex_dataset_api/metadata.py
+++ b/timdex_dataset_api/metadata.py
@@ -1,0 +1,294 @@
+"""timdex_dataset_api/metadata.py"""
+
+import time
+from typing import TYPE_CHECKING, Unpack
+
+import duckdb
+
+from timdex_dataset_api.config import configure_logger
+
+if TYPE_CHECKING:
+    from timdex_dataset_api.dataset import DatasetFilters, TIMDEXDataset
+
+logger = configure_logger(__name__)
+
+
+class TIMDEXDatasetMetadata:
+    """Collect and provide access to metadata about the parquet dataset.
+
+    The ETL parquet dataset is essentially parquet files in S3.  This class utilizes
+    DuckDB to generate metadata about the parquet dataset, down to the individual record
+    layer.  This is somewhat similar to how other data lakes like Apache Iceberg or
+    DuckDB DuckLake provide a metadata layer over the stored, large, raw files.
+
+    Because this metadata is somewhat infrequently needed, e.g. only for bulk operations
+    or analysis, the architectural decision has been made to pay an initial time penalty
+    of crawling the dataset to generate metadata which is then used to dramatically
+    speed up and simplify other operations.  In the event this dataset-wide metadata
+    is needed more often, it may be worth exploring storing it in S3 alongside the data
+    and updating it for each write; very much mirroring other data lake frameworks.
+    """
+
+    def __init__(
+        self,
+        timdex_dataset: "TIMDEXDataset",
+        db_path: str = ":memory:",
+    ):
+        """Initialize TIMDEXDatasetMetadata.
+
+        Args:
+            timdex_dataset: The TIMDEX dataset instance to extract metadata from
+            db_path: Path to the DuckDB database file. Defaults to ":memory:" for
+                in-memory database
+        """
+        self.timdex_dataset = timdex_dataset
+        self.db_path = db_path
+
+        self.conn = self.get_connection()
+        self._setup_database()
+
+    @classmethod
+    def from_dataset_location(
+        cls,
+        timdex_dataset_location: str,
+        **kwargs: str,
+    ) -> "TIMDEXDatasetMetadata":
+        """Factory method to init TIMDEXDatasetMetadata from a dataset location.
+
+        This first instantiates and loads a TIMDEXDataset instance, then instantiates this
+        class using that.  While this class will likely most commonly be used by
+        TIMDEXDataset to limit to current records, it is hoped and expected this dataset
+        metadata client will be increasingly useful in its own right, thus this method.
+
+        Args:
+            timdex_dataset_location: S3 path or local path to the TIMDEX dataset
+            **kwargs: Additional keyword arguments passed to the class constructor,
+                such as db_path
+        """
+        # avoids circular import dependency
+        from .dataset import TIMDEXDataset  # noqa: PLC0415
+
+        timdex_dataset = TIMDEXDataset(timdex_dataset_location)
+        timdex_dataset.load()
+        return cls(timdex_dataset, **kwargs)
+
+    def get_connection(self) -> duckdb.DuckDBPyConnection:
+        """Get a DuckDB connection to the metadata database."""
+        return duckdb.connect(self.db_path)
+
+    def set_database_thread_usage(self, thread_count: int) -> None:
+        """Set the number of threads for DuckDB operations."""
+        self.conn.execute(f"""SET threads = {thread_count};""")
+
+    def _setup_database(self) -> None:
+        """Initialize DuckDB database with AWS credentials and base tables and views."""
+        start_time = time.perf_counter()
+
+        # bump threads for high parallelization of lightweight data calls for metadata
+        self.set_database_thread_usage(64)
+
+        # setup AWS credentials chain
+        self._create_aws_credential_chain()
+
+        # create a table of metadata about all rows in dataset
+        self._create_full_dataset_table()
+
+        # create a view for current records
+        self._create_current_records_view()
+
+        logger.info(
+            f"metadata database setup elapsed: {time.perf_counter()-start_time}, "
+            f"path: '{self.db_path}'"
+        )
+
+    def _create_aws_credential_chain(self) -> None:
+        """Setup AWS credentials chain in database connection.
+
+        https://duckdb.org/docs/stable/core_extensions/aws.html
+        """
+        logger.info("setting up AWS credentials chain")
+        query = """
+        create or replace secret secret (
+            type s3,
+            provider credential_chain,
+            chain 'sso;env;config',
+            refresh true
+        );
+        """
+        self.conn.execute(query)
+
+    def _create_full_dataset_table(self) -> None:
+        """Create a table of metadata about all records in the parquet dataset.
+
+        While this table will obviously have a high number of rows, the data is small.
+        Testing has shown around 20 million records results in 1gb in memory or ~150mb on
+        disk.
+        """
+        start_time = time.perf_counter()
+        logger.info("creating table of full dataset metadata")
+
+        parquet_glob_pattern = self._prepare_parquet_file_glob_pattern()
+        query = f"""
+        create or replace table records as (
+            select
+                timdex_record_id,
+                source,
+                run_date,
+                run_type,
+                run_id,
+                action,
+                run_record_offset,
+                run_timestamp,
+                filename,
+            from read_parquet(
+                {parquet_glob_pattern},
+                 hive_partitioning=true,
+                 filename=true
+             )
+        );
+        """
+        self.conn.execute(query)
+
+        row_count = self.conn.query("""select count(*) from records;""").fetchone()[0]  # type: ignore[index]
+        logger.info(
+            f"'records' table created - rows: {row_count}, "
+            f"elapsed: {time.perf_counter() - start_time}"
+        )
+
+    def _prepare_parquet_file_glob_pattern(self) -> str:
+        """Prepare a parquet file glob pattern suitable for DuckDB read_parquet()."""
+        if isinstance(self.timdex_dataset.location, list):
+            return ",".join([f"'{file}'" for file in self.timdex_dataset.location])
+
+        prefix = self.timdex_dataset.location.removesuffix("/")
+        return f"'{prefix}/**/*.parquet'"
+
+    def _create_current_records_view(self) -> None:
+        """Create a view of current records.
+
+        This view builds on the table `records`.
+
+        This view includes only the most current version of each record in the dataset.
+        Because it includes the `timdex_record_id` and `run_id`, it makes yielding the
+        current version of a record via a TIMDEXDataset instance trivial: for any given
+        `timdex_record_id` if the `run_id` doesn't match, it's not the current version.
+        """
+        start_time = time.perf_counter()
+        logger.info("creating view of current records metadata")
+
+        query = """
+        create or replace view current_records as
+        with ranked_records as (
+            select
+                r.*,
+                row_number() over (
+                    partition by r.timdex_record_id
+                    order by r.run_timestamp desc
+                ) as rn
+            from records r
+            where r.run_timestamp >= (
+                select max(r2.run_timestamp)
+                from records r2
+                where r2.source = r.source
+                and r2.run_type = 'full'
+            )
+        )
+        select
+            timdex_record_id,
+            source,
+            run_date,
+            run_type,
+            run_id,
+            action,
+            run_record_offset,
+            run_timestamp,
+            filename
+        from ranked_records
+        where rn = 1;
+        """
+        self.conn.execute(query)
+
+        row_count = self.conn.query(  # type: ignore[index]
+            """select count(*) from current_records;"""
+        ).fetchone()[0]
+        logger.info(
+            f"'current_records' view created - rows: {row_count}, "
+            f"elapsed: {time.perf_counter() - start_time}"
+        )
+
+    def get_current_parquet_files(
+        self,
+        *,
+        strip_protocol_prefix: bool = True,
+        **filters: Unpack["DatasetFilters"],
+    ) -> list[str]:
+        """Provide a list of parquet files that contain one or more current records.
+
+        Args:
+            - strip_protocol_prefix: boolean if the file protocol should be removed,
+                e.g. "s3://"
+            - **filters: keyword dataset filters like `source="alma"` or
+                `run_date="2025-05-01"`
+        """
+        where_clause = self._prepare_where_clause_from_dataset_filters(**filters)
+
+        query = f"""
+        select distinct
+            filename as parquet_filename
+        from current_records
+        {where_clause}
+        order by run_timestamp desc;
+        """
+        parquet_files_df = self.conn.query(query).to_df()
+
+        if strip_protocol_prefix:
+            parquet_files_df["parquet_filename"] = parquet_files_df[
+                "parquet_filename"
+            ].apply(lambda x: x.removeprefix("s3://"))
+
+        return list(parquet_files_df["parquet_filename"])
+
+    def get_current_record_to_run_map(self, **filters: Unpack["DatasetFilters"]) -> dict:
+        """Provide a dictionary of timdex_record_id --> run_id for current records.
+
+        This dictionary is all that read methods in TIMDEXDataset would require to ensure
+        they only yield the current version of a record.
+
+        Args:
+            - **filters: keyword dataset filters like `source="alma"` or
+                `run_date="2025-05-01"`
+        """
+        start_time = time.perf_counter()
+
+        where_clause = self._prepare_where_clause_from_dataset_filters(**filters)
+
+        query = f"""
+        select
+            timdex_record_id,
+            run_id
+        from current_records
+        {where_clause}
+        ;
+        """
+        mapper_df = self.conn.query(query).to_df()
+        mapper_dict = mapper_df.set_index("timdex_record_id")["run_id"].to_dict()
+        logger.info(
+            f"Record-to-run mapper dict created elapsed: {time.perf_counter()-start_time}"
+        )
+        return mapper_dict
+
+    def _prepare_where_clause_from_dataset_filters(
+        self, **filters: Unpack["DatasetFilters"]
+    ) -> str:
+        """Given keyword filters from DatasetFilters, provide a SQL WHERE clause.
+
+        Note: this implementation of translating TIMDEXDataset DatasetFilters to a single
+        SQL WHERE clause is quite naive.  This does the trick for now, supporting filters
+        like `source` or `run_date`, but this should be revisited if more robust filtering
+        is needed.
+        """
+        conditions = [f"{column} = '{value}'" for column, value in filters.items()]
+
+        if conditions:
+            return f"where {' and '.join(conditions)}"
+        return ""


### PR DESCRIPTION
### Purpose and background context

This PR introduces `TIMDEXDatasetMetadata` to provide metadata about the ETL parquet dataset.  As noted in [TIMX-506](https://mitlibraries.atlassian.net/browse/TIMX-506), the ultimate goal is to replace `TIMDEXRunManager`.

`TIMDEXRunManager` used fairly low-level pyarrow mechanics to get data about parquet files.  It was performant, but had a latent weakness: it assumed that each parquet file was associated with only **one** ETL run.  If that were ever not true, the data it provided about ETL runs would be wrong.  This limits our ability to evolve our parquet dataset, e.g. [parquet file compaction](https://medium.com/bigspark/compaction-merge-of-small-parquet-files-bef60847e60b). 

Furthermore, it only provided run-level metadata.  This _helped_ with yielding of current records by giving us some data to work with, but the level of detail that provided still required some complex operations to yield current records.  All the while, vulnerable to the implicit data contracts mentioned above.

All of this goes away with `TIMDEXDatasetMetadata`!  A different approach is taken, leaning on DuckDB, to retrieve record-level metadata from the dataset.  While the initial load time for this metadata is a bit longer -- maybe 10-20 seconds -- the data produced makes all operations much simpler.  Example: `TIMDEXDatasetMetadata` will produce a dictionary mapping each `timdex_record_id` to the `run_id` that is current for it.  Using that, we can fairly naively loop through records in the dataset only yielding them if the `timdex_record_id` + `run_id` match the dictionary we now have.  This _greatly_ simplifies all `current_records=True` behavior.

**Lastly, are questions of scale and performance.**

Initial testing shows for the current ~5 million rows we have in our production dataset, at around 10gb, loading of a `TIMDEXDatasetMetadata` instances takes about 20 seconds from a developer machine.  It may be a bit faster or slower from a deployed lambda, but likely in that ballpark.

In good news, this load time does not appear to increase linearly.  A test dataset has been created with 20 million records (reflecting approximately 2 years of TIMDEX ETL runs), `s3://ghukill-test/timdex-dataset/scale_test/`, where load times are still around 30 seconds.  Given no real optimizations are applied, or parquet file compaction, this suggests this will scale well.

Additionally, it is fairly evident this dataset metadata is not _frequently_ needed.  It will be essential for operations like source bulk-reindexing, or record analysis, but it is not require for day-to-day ETL runs.  As such, the tradeoff of a 30 second load time for the excellent performance and simplicity it offers feels like a good one.

Lastly, conceptually, it is very closely aligned with other data lake architectures like Apache Iceberg or DuckDB DuckLake.  Short of actually migrating to one of those proper, it's been demostrated that this general approach is sound.

This PR introduces the new class `TIMDEXDatasetMetadata`, but does not wire it into the `.load(current_records=True)` mechanics yet.  That will be covered in [TIMX-507](https://mitlibraries.atlassian.net/browse/TIMX-506).

This class will also be used for a data migration -- a good example of how it's useful -- that is sketched out in [TIMX-508](https://mitlibraries.atlassian.net/browse/TIMX-508).

### How can a reviewer manually see the effects of these changes?

TODO...

### Includes new or updated dependencies?
YES

### Changes expectations for external applications?
NO: not at this time

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-506

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

