### PR TITLE
TIMX 512 - row group size data migration

### DIFF
--- a/migrations/003_2025_07_03_fix_row_group_sizes.py
+++ b/migrations/003_2025_07_03_fix_row_group_sizes.py
@@ -1,0 +1,131 @@
+# ruff: noqa: BLE001, D212, RUF002, RUF001, TRY400
+
+"""
+Date: 2025-07-03
+
+Description:
+
+Re‑pack any Parquet file in a TIMDEX dataset that still has **one** oversized row‑group
+so that no group exceeds the configured `TDA_MAX_ROWS_PER_GROUP` (defaults to 1k).
+
+Usage
+-----
+PYTHONPATH=. \
+pipenv run python migrations/003_2025_07_03_fix_row_group_sizes.py \
+<DATASET_LOCATION> \
+--dry-run
+"""
+
+import argparse
+import logging
+import time
+from math import ceil
+
+import pyarrow.dataset as ds
+import pyarrow.parquet as pq
+from pyarrow import fs
+
+from timdex_dataset_api.config import configure_dev_logger
+from timdex_dataset_api.dataset import (
+    TIMDEXDataset,
+    TIMDEXDatasetConfig,
+)
+
+configure_dev_logger()
+
+DEFAULT_ROWS_PER_GROUP: int = TIMDEXDatasetConfig().max_rows_per_group
+DEFAULT_COMPRESSION: str | None = "snappy"
+
+log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+def needs_rewrite(pf: pq.ParquetFile, rows_per_group: int) -> bool:
+    return pf.metadata.num_row_groups == 1 and pf.metadata.num_rows > rows_per_group
+
+
+def rewrite_file(
+    path: str,
+    filesystem: fs.FileSystem,
+    *,
+    dry_run: bool = False,
+) -> None:
+    pf = pq.ParquetFile(path, filesystem=filesystem)
+
+    codec = pf.metadata.row_group(0).column(0).compression
+    compression = None if codec.upper() == "UNCOMPRESSED" else codec.lower()
+
+    if dry_run:
+        log.info(
+            f"[DRY‑RUN] {path} — would split {pf.metadata.num_rows:,} rows "
+            f"into {ceil(pf.metadata.num_rows / DEFAULT_ROWS_PER_GROUP):,} row‑groups"
+        )
+        return
+
+    table = pf.read()
+
+    pq.write_table(
+        table,
+        path,
+        filesystem=filesystem,
+        row_group_size=DEFAULT_ROWS_PER_GROUP,
+        compression=compression,  # type: ignore[arg-type]
+    )
+
+    log.info(
+        f"[OK] {path} — {pf.metadata.num_rows:,} rows now split into "
+        f"{ceil(pf.metadata.num_rows / DEFAULT_ROWS_PER_GROUP):,} row‑groups"
+    )
+
+
+def fix_row_groups(
+    location: str,
+    *,
+    dry_run: bool = False,
+) -> None:
+    start = time.perf_counter()
+
+    filesystem, dataset_root = TIMDEXDataset.parse_location(location)
+    if isinstance(dataset_root, list):
+        raise TypeError("Expected a single dataset root path, not a list.")
+
+    dataset = ds.dataset(dataset_root, format="parquet", filesystem=filesystem)
+
+    rewritten = skipped = errors = 0
+    for file_path in dataset.files:
+        try:
+            pf = pq.ParquetFile(file_path, filesystem=filesystem)
+            if needs_rewrite(pf, DEFAULT_ROWS_PER_GROUP):
+                rewrite_file(
+                    file_path,
+                    filesystem,
+                    dry_run=dry_run,
+                )
+                rewritten += 1
+            else:
+                skipped += 1
+        except Exception as exc:
+            log.error(f"[ERR] {file_path}: {exc}")
+            errors += 1
+
+    elapsed = time.perf_counter() - start
+    log.info(
+        f"Done in {elapsed:.1f}s — rewritten: {rewritten}, "
+        f"skipped: {skipped}, errors: {errors}"
+    )
+
+
+def _parse_args() -> tuple[str, bool]:
+    p = argparse.ArgumentParser(
+        description="Re‑pack Parquet files so no row‑group exceeds the configured size."
+    )
+    p.add_argument("dataset_location")
+    p.add_argument("--dry-run", action="store_true")
+
+    a = p.parse_args()
+    return a.dataset_location, a.dry_run
+
+
+if __name__ == "__main__":
+    location, dry_run = _parse_args()
+    fix_row_groups(location, dry_run=dry_run)


### PR DESCRIPTION
### Purpose and background context

It was discovered that some parquet files, mostly those before `2025-06-28`, may have a single, large row group instead of multiple row groups with a maximum row count of 1k (when the parquet file has 1k+ total records).

This has been addressed in recent work, resulting in no files on or after `2025-06-28` having a single row group if total rows exceed 1k.

This migration script re-packs row groups (rewrites) in a parquet file when a single row group is found for a number of rows that should be split up.

### How can a reviewer manually see the effects of these changes?

A clone of production, and a clone with the migration applied, has been written to a testing location: `s3://ghukill-test/timdex-dataset/row-group-testing/`.

You can point the script with the `--dry-run` flag to see that the clone still shows files that need updating, while the other dataset with the script applies skips all files because they have correct row groups.

1- Set AWS dev credentials

2- Run dry run for pre-fix dataset:
```
PYTHONPATH=. \
pipenv run python migrations/003_2025_07_03_fix_row_group_sizes.py \
s3://ghukill-test/timdex-dataset/row-group-testing/prod \
--dry-run
```

3- Run dry run for post-fix dataset:
```
PYTHONPATH=. \
pipenv run python migrations/003_2025_07_03_fix_row_group_sizes.py \
s3://ghukill-test/timdex-dataset/row-group-testing/prod_003 \
--dry-run
```
- NOTE: no output until fully complete, indicating all files skipped

While difficult to recreate, I've also performed some "needle in a haystack" queries to retrieve records using their `run_record_offset` to help prune row groups.  The dataset with the fix show significant -- orders of magnitude -- faster retrieval because libraries like DuckDB and pyarrow can now skip row groups where the _sorted_ `run_record_offset` won't be found.

Here is some output from these tests; happy to discuss more or demonstrate how to recreate if people are curious:

```
################## PRE FIX ###################
INFO:timdex_dataset_api.dataset:Dataset successfully loaded: 's3://ghukill-test/timdex-dataset/row-group-testing/prod', 1.55s
INFO:timdex_dataset_api.metadata:setting up AWS credentials chain
INFO:timdex_dataset_api.metadata:creating table of full dataset metadata
100% ▕████████████████████████████████████████████████████████████▏
INFO:timdex_dataset_api.metadata:'records' table created - rows: 5339546, elapsed: 11.17069770814851
INFO:timdex_dataset_api.metadata:creating view of current records metadata
INFO:timdex_dataset_api.metadata:'current_records' view created - rows: 4333305, elapsed: 1.6118598342873156
INFO:timdex_dataset_api.metadata:metadata database setup elapsed: 13.556067041121423, path: ':memory:'
DEBUG:timdex_dataset_api.metadata:Retrieving full record from dataset - timdex_record_id: alma:9935071191506761
DEBUG:timdex_dataset_api.metadata:Parquet file identified: s3://ghukill-test/timdex-dataset/row-group-testing/prod/year=2025/month=02/day=28/64ceec69-47a0-4518-84fd-5dc6b141ff81-0.parquet, run_record_offset: 86787, elapsed: 0.18271237518638372
100% ▕████████████████████████████████████████████████████████████▏
DEBUG:timdex_dataset_api.metadata:Full record retrieved, elapsed: 11.743179291952401, total elapsed: 11.92612566659227

################## POST FIX ###################
INFO:timdex_dataset_api.dataset:Dataset successfully loaded: 's3://ghukill-test/timdex-dataset/row-group-testing/prod_003', 1.56s
INFO:timdex_dataset_api.metadata:setting up AWS credentials chain
INFO:timdex_dataset_api.metadata:creating table of full dataset metadata
100% ▕████████████████████████████████████████████████████████████▏
INFO:timdex_dataset_api.metadata:'records' table created - rows: 5339546, elapsed: 35.869934416841716
INFO:timdex_dataset_api.metadata:creating view of current records metadata
INFO:timdex_dataset_api.metadata:'current_records' view created - rows: 4333305, elapsed: 1.0270889168605208
INFO:timdex_dataset_api.metadata:metadata database setup elapsed: 37.60139649966732, path: ':memory:'
DEBUG:timdex_dataset_api.metadata:Retrieving full record from dataset - timdex_record_id: alma:9935071191506761
DEBUG:timdex_dataset_api.metadata:Parquet file identified: s3://ghukill-test/timdex-dataset/row-group-testing/prod_003/year=2025/month=02/day=28/64ceec69-47a0-4518-84fd-5dc6b141ff81-0.parquet, run_record_offset: 86787, elapsed: 0.052597166039049625
DEBUG:timdex_dataset_api.metadata:Full record retrieved, elapsed: 0.8138260003179312, total elapsed: 0.8665646249428391
```

The key thing to look for is the time `"Full record retrieved, elapsed"` in the last line of each, which demonstrates the speedup.  We go from ~11 seconds to ~0.8 seconds, which is almost pure network I/O of downloading bytes we didn't need.

It's worth noting that generating the dataset metadata is a bit _slower_ now due to more row groups.  But as discussed, we are willing to pay a slight time penalty for generating the metadata, in the name of speeding up other operations.


### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-512