### PR TITLE
TIMX 515 - static DuckDB file prep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+-include .env
+
 SHELL=/bin/bash
 DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
 
@@ -54,3 +56,16 @@ black-apply: # Apply changes with 'black'
 
 ruff-apply: # Resolve 'fixable errors' with 'ruff'
 	pipenv run ruff check --fix .
+
+
+######################
+# Minio S3 Instance
+######################
+minio-start:
+	docker run \
+   -p 9000:9000 \
+   -p 9001:9001 \
+   -v $(MINIO_DATA):/data \
+   -e "MINIO_ROOT_USER=$(MINIO_USERNAME)" \
+   -e "MINIO_ROOT_PASSWORD=$(MINIO_PASSWORD)" \
+   quay.io/minio/minio server /data --console-address ":9001"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,30 @@ None at this time.
 ```shell
 TDA_LOG_LEVEL=# log level for timdex-dataset-api, accepts [DEBUG, INFO, WARNING, ERROR], default INFO
 WARNING_ONLY_LOGGERS=# Comma-seperated list of logger names to set as WARNING only, e.g. 'botocore,charset_normalizer,smart_open'
+
+MINIO_S3_ENDPOINT_URL=# If set, informs the library to use this Minio S3 instance.  Requires the http(s):// protocol. 
+MINIO_USERNAME=# Username / AWS Key for Minio; required when MINIO_S3_ENDPOINT_URL is set
+MINIO_PASSWORD=# Pasword / AWS Secret for Minio; required when MINIO_S3_ENDPOINT_URL is set
+MINIO_DATA=# Path to persist MinIO data if started via Makefile command 
 ```
+
+## Local S3 via MinIO
+
+Set env vars:
+```shell
+MINIO_S3_ENDPOINT_URL=http://localhost:9000
+MINIO_USERNAME="admin"
+MINIO_PASSWORD="password"
+MINIO_DATA=<path to persist MinIO data, e.g. /tmp/minio>
+```
+
+Use a `Makefile` command that will start a MinIO instance:
+
+```shell
+make minio-start
+```
+
+With the env var `MINIO_S3_ENDPOINT_URL` set, this library will configure `pyarrow` and DuckDB connections to point at this local MinIO S3 instance.
 
 ## Usage
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ def _test_env(monkeypatch):
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "fake_secret_key")
     monkeypatch.setenv("AWS_SESSION_TOKEN", "fake_session_token")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.delenv("MINIO_S3_ENDPOINT_URL", raising=False)
 
 
 @pytest.fixture

--- a/timdex_dataset_api/dataset.py
+++ b/timdex_dataset_api/dataset.py
@@ -128,7 +128,7 @@ class TIMDEXDataset:
 
         # reading
         self._current_records: bool = False
-        self.timdex_dataset_metadata: TIMDEXDatasetMetadata = None  # type: ignore[assignment]
+        self.metadata: TIMDEXDatasetMetadata = None  # type: ignore[assignment]
 
     @property
     def row_count(self) -> int:
@@ -173,8 +173,8 @@ class TIMDEXDataset:
         # read dataset metadata if only current records are requested
         self._current_records = current_records
         if current_records:
-            self.timdex_dataset_metadata = TIMDEXDatasetMetadata(timdex_dataset=self)
-            self.paths = self.timdex_dataset_metadata.get_current_parquet_files(**filters)
+            self.metadata = TIMDEXDatasetMetadata(timdex_dataset=self)
+            self.paths = self.metadata.get_current_parquet_files(**filters)
 
         # perform initial load of full dataset
         self.dataset = self._load_pyarrow_dataset()
@@ -521,9 +521,7 @@ class TIMDEXDataset:
             - filters: pairs of column:value to filter the dataset metadata required
         """
         # get map of timdex_record_id to run_id for current version of that record
-        record_to_run_map = self.timdex_dataset_metadata.get_current_record_to_run_map(
-            **filters
-        )
+        record_to_run_map = self.metadata.get_current_record_to_run_map(**filters)
 
         # loop through batches, yielding only current records
         for batch in batches:

--- a/timdex_dataset_api/metadata.py
+++ b/timdex_dataset_api/metadata.py
@@ -115,24 +115,28 @@ class TIMDEXDatasetMetadata:
         if os.getenv("MINIO_S3_ENDPOINT_URL"):
             self.conn.execute(
                 f"""
-            PRAGMA s3_endpoint='{urlparse(os.environ["MINIO_S3_ENDPOINT_URL"]).netloc}';
-            PRAGMA s3_access_key_id='{os.environ["MINIO_USERNAME"]}';
-            PRAGMA s3_secret_access_key='{os.environ["MINIO_PASSWORD"]}';
-            PRAGMA s3_use_ssl=false;
-            PRAGMA s3_url_style='path';
-            """
+                create or replace secret minio_s3_secret (
+                    type s3,
+                    endpoint '{urlparse(os.environ["MINIO_S3_ENDPOINT_URL"]).netloc}',
+                    key_id '{os.environ["MINIO_USERNAME"]}',
+                    secret '{os.environ["MINIO_PASSWORD"]}',
+                    region 'us-east-1',
+                    url_style 'path',
+                    use_ssl false
+                );
+                """
             )
 
         else:
             self.conn.execute(
                 """
-            create or replace secret secret (
-                type s3,
-                provider credential_chain,
-                chain 'sso;env;config',
-                refresh true
-            );
-            """
+                create or replace secret aws_s3_secret (
+                    type s3,
+                    provider credential_chain,
+                    chain 'sso;env;config',
+                    refresh true
+                );
+                """
             )
 
     def _create_full_dataset_table(self) -> None:


### PR DESCRIPTION
### Purpose and background context

This PR adds support for a local MinIO S3 instance as prep work for the more involved work in [TIMX-515](https://mitlibraries.atlassian.net/browse/TIMX-515).

As we begin to explore the management of a static file in S3, it will be handy to have easy pathways for more local dev and testing while still getting the constraints and edge cases of AWS S3.

Additionally, renamed the attached `TIMDEXDatasetMetadata` instance on `TIMDEXDataset` to just `.metadata`, inline with potentially more common and frequent usage.

There is no dedicated ticket for this work, just some prep work.

### How can a reviewer manually see the effects of these changes?

1- Set the following env vars:

```shell
MINIO_S3_ENDPOINT_URL=http://localhost:9000
MINIO_USERNAME="admin"
MINIO_PASSWORD="password"
MINIO_DATA=/tmp/tda-minio
```

2- Run MinIO server and create structure:

```shell
make minio-start
```
* navigate to http://localhost:9001 and login with credentials `admin` / `password`
* create a bucket called `timdex`

3- Start ipython shell:

```shell
pipenv run ipython
```

4- Write some data to the empty dataset, confirming writes to MinIO work:

```python
from timdex_dataset_api import TIMDEXDataset
from tests.utils import generate_sample_records

td = TIMDEXDataset("s3://timdex/dataset")

writes = [
    generate_sample_records(100, source='alma', run_type='full', run_date='2025-07-01', timdex_record_id_prefix='alma'),
    generate_sample_records(50, source='alma', run_date='2025-07-02', timdex_record_id_prefix='alma'),
    generate_sample_records(50, source='libguides', run_type='full', run_date='2025-07-11', timdex_record_id_prefix='libguies'),
]
for records in writes:
    td.write(records)
```

5- Reload the dataset with current records only, triggering the use of `TIMDEXDatasetMetadata` and run a couple of metadata queries, demonstrating that reading files from MinIO works for `pyarrow` for `TIMDEXDataset` loading and via DuckDB for `TIMDEXDatasetMetadata` queries:

```python
from timdex_dataset_api import TIMDEXDataset
from  timdex_dataset_api.config import configure_dev_logger

configure_dev_logger()

td = TIMDEXDataset("s3://timdex/dataset")
td.load(current_records=True)
"""
INFO:timdex_dataset_api.metadata:configuring S3 connection
INFO:timdex_dataset_api.metadata:creating table of full dataset metadata
INFO:timdex_dataset_api.metadata:'records' table created - rows: 200, elapsed: 0.04554949980229139
INFO:timdex_dataset_api.metadata:creating view of current records metadata
INFO:timdex_dataset_api.metadata:'current_records' view created - rows: 150, elapsed: 0.007222665939480066
INFO:timdex_dataset_api.metadata:metadata database setup elapsed: 0.09048424987122416, path: ':memory:'
INFO:timdex_dataset_api.dataset:Dataset successfully loaded: 's3://timdex/dataset', 0.11s
"""

td.metadata.conn.query("""select source, count(*) from records group by source;""")
"""
Out[3]: 
┌───────────┬──────────────┐
│  source   │ count_star() │
│  varchar  │    int64     │
├───────────┼──────────────┤
│ alma      │          150 │
│ libguides │           50 │
└───────────┴──────────────┘
"""

td.metadata.conn.query("""select source, count(*) from current_records group by source;""")
"""
Out[4]: 
┌───────────┬──────────────┐
│  source   │ count_star() │
│  varchar  │    int64     │
├───────────┼──────────────┤
│ alma      │          100 │ <------- 50 fewer records because not all current
│ libguides │           50 │
└───────────┴──────────────┘
"""
```

These operations demonstrate that the MinIO S3 instance is successfully used for read/write operations, from both `pyarrow` and `DuckDB`.


### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-515

[TIMX-515]: https://mitlibraries.atlassian.net/browse/TIMX-515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ