### PR TITLE
TIMX 527 - write append deltas

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -22,25 +22,23 @@
                 "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==25.3.0"
         },
         "boto3": {
             "hashes": [
-                "sha256:959443055d2af676c336cc6033b3f870a8a924384b70d0b2905081d649378179",
-                "sha256:fc1b3ca3baf3d8820c6faddf47cbba8ad3cd16f8e8d7e2f76d304bf995932eb7"
+                "sha256:2dfbc214fdbf94abfd61eec687ea39089d05af43bb00be792c76f3a6c1393f7b",
+                "sha256:3d99325ee874190e8f3bfd38823987327c826cdfbab943420851bdb7684d727c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
-            "version": "==1.40.0"
+            "version": "==1.40.2"
         },
         "botocore": {
             "hashes": [
-                "sha256:2063e6d035a6a382b2ae37e40f5144044e55d4e091910d0c9f1be3121ad3e4e6",
-                "sha256:850242560dc8e74d542045a81eb6cc15f1b730b4ba55ba5b30e6d686548dfcaf"
+                "sha256:77c4710bf37b28e897833b5b1f47d6a83e45a29985cd01a560dfdb8b6ad524e5",
+                "sha256:a31e6269af05498f8dc1c7f2b3f34448a0f16c79a8601c0389ecddab51b2c2ab"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.40.0"
+            "version": "==1.40.2"
         },
         "duckdb": {
             "hashes": [
@@ -82,7 +80,6 @@
                 "sha256:e584f25892450757919639b148c2410402b17105bd404017a57fa9eec9c98919"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.7.0'",
             "version": "==1.3.2"
         },
         "jmespath": {
@@ -170,7 +167,7 @@
                 "sha256:fc927d7f289d14f5e037be917539620603294454130b6de200091e23d27dc9be",
                 "sha256:fed5527c4cf10f16c6d0b6bee1f89958bccb0ad2522c8cadc2efd318bcd545f5"
             ],
-            "markers": "python_version >= '3.11'",
+            "markers": "python_version >= '3.12'",
             "version": "==2.3.2"
         },
         "pandas": {
@@ -219,7 +216,6 @@
                 "sha256:fe7317f578c6a153912bd2292f02e40c1d8f253e93c599e82620c7f69755c74f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==2.3.1"
         },
         "pyarrow": {
@@ -269,7 +265,6 @@
                 "sha256:fee33b0ca46f4c85443d6c450357101e47d53e6c3f008d658c27a2d020d44c79"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==21.0.0"
         },
         "python-dateutil": {
@@ -277,7 +272,7 @@
                 "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
                 "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9.0.post0"
         },
         "pytz": {
@@ -300,7 +295,7 @@
                 "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
                 "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.17.0"
         },
         "tzdata": {
@@ -316,7 +311,7 @@
                 "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760",
                 "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"
             ],
-            "markers": "python_version >= '3.9'",
+            "markers": "python_version >= '3.10'",
             "version": "==2.5.0"
         }
     },
@@ -355,7 +350,6 @@
                 "sha256:f3df5f1bf91d36002b0a75389ca8663510cf0531cca8aa5c1ef695b46d98655f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==25.1.0"
         },
         "boolean.py": {
@@ -367,31 +361,30 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:959443055d2af676c336cc6033b3f870a8a924384b70d0b2905081d649378179",
-                "sha256:fc1b3ca3baf3d8820c6faddf47cbba8ad3cd16f8e8d7e2f76d304bf995932eb7"
+                "sha256:2dfbc214fdbf94abfd61eec687ea39089d05af43bb00be792c76f3a6c1393f7b",
+                "sha256:3d99325ee874190e8f3bfd38823987327c826cdfbab943420851bdb7684d727c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
-            "version": "==1.40.0"
+            "version": "==1.40.2"
         },
         "boto3-stubs": {
             "extras": [
                 "essential"
             ],
             "hashes": [
-                "sha256:43898929cfab6c59cb9a3b0ba768d85346e4c1c1757710525d5031b50dda32d6",
-                "sha256:acc75cdd519bd6c06dc79c53fc6bd4ffe2f72f7e2e374ae9cac106b1f8ba5ee1"
+                "sha256:0a4b31f11b483f51e5bfab59802ed7c0c6651ac29855cf08615f0145fbf32196",
+                "sha256:6ab5b88743ad0529bc1b6f328fc3a25e009185305facc3b95cd3a972d19c2f89"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.40.0"
+            "index": "pypi",
+            "version": "==1.40.2"
         },
         "botocore": {
             "hashes": [
-                "sha256:2063e6d035a6a382b2ae37e40f5144044e55d4e091910d0c9f1be3121ad3e4e6",
-                "sha256:850242560dc8e74d542045a81eb6cc15f1b730b4ba55ba5b30e6d686548dfcaf"
+                "sha256:77c4710bf37b28e897833b5b1f47d6a83e45a29985cd01a560dfdb8b6ad524e5",
+                "sha256:a31e6269af05498f8dc1c7f2b3f34448a0f16c79a8601c0389ecddab51b2c2ab"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.40.0"
+            "version": "==1.40.2"
         },
         "botocore-stubs": {
             "hashes": [
@@ -414,11 +407,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2",
-                "sha256:8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995"
+                "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407",
+                "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2025.7.14"
+            "version": "==2025.8.3"
         },
         "cffi": {
             "hashes": [
@@ -490,7 +483,7 @@
                 "sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87",
                 "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "platform_python_implementation != 'PyPy'",
             "version": "==1.17.1"
         },
         "cfgv": {
@@ -612,97 +605,97 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:042125c89cf74a074984002e165d61fe0e31c7bd40ebb4bbebf07939b5924613",
-                "sha256:083442ecf97d434f0cb3b3e3676584443182653da08b42e965326ba12d6b5f2a",
-                "sha256:1217a54cfd79be20512a67ca81c7da3f2163f51bbfd188aab91054df012154f5",
-                "sha256:166d89c57e877e93d8827dac32cedae6b0277ca684c6511497311249f35a280c",
-                "sha256:1a108dd78ed185020f66f131c60078f3fae3f61646c28c8bb4edd3fa121fc7fc",
-                "sha256:1aadfb06a30c62c2eb82322171fe1f7c288c80ca4156d46af0ca039052814bab",
-                "sha256:1c4f679c6b573a5257af6012f167a45be4c749c9925fd44d5178fd641ad8bf72",
-                "sha256:1c86eb388bbd609d15560e7cc0eb936c102b6f43f31cf3e58b4fd9afe28e1372",
-                "sha256:1e0c768b0f9ac5839dac5cf88992a4bb459e488ee8a1f8489af4cb33b1af00f1",
-                "sha256:21eb7d8b45d3700e7c2936a736f732794c47615a20f739f4133d5230a6512a88",
-                "sha256:2348631f049e884839553b9974f0821d39241c6ffb01a418efce434f7eba0fe7",
-                "sha256:283005bb4d98ae33e45f2861cd2cde6a21878661c9ad49697f6951b358a0379b",
-                "sha256:2b225a06d227f23f386fdc0eab471506d9e644be699424814acc7d114595495f",
-                "sha256:320d86da829b012982b414c7cdda65f5d358d63f764e0e4e54b33097646f39a3",
-                "sha256:37b69226001d8b7de7126cad7366b0778d36777e4d788c66991455ba817c5b41",
-                "sha256:3a7a4d74cb0f5e3334f9aa26af7016ddb94fb4bfa11b4a573d8e98ecba8c34f1",
-                "sha256:3beb76e20b28046989300c4ea81bf690df84ee98ade4dc0bbbf774a28eb98440",
-                "sha256:3e31dfb8271937cab9425f19259b1b1d1f556790e98eb266009e7a61d337b6d4",
-                "sha256:3e59d00830da411a1feef6ac828b90bbf74c9b6a8e87b8ca37964925bba76dbe",
-                "sha256:4072b31361b0d6d23f750c524f694e1a417c1220a30d3ef02741eed28520c48e",
-                "sha256:40f9a38676f9c073bf4b9194707aa1eb97dca0e22cc3766d83879d72500132c7",
-                "sha256:47ab6dbbc31a14c5486420c2c1077fcae692097f673cf5be9ddbec8cdaa4cdbc",
-                "sha256:47c91f32ba4ac46f1e224a7ebf3f98b4b24335bad16137737fe71a5961a0665c",
-                "sha256:4fcfe294f95b44e4754da5b58be750396f2b1caca8f9a0e78588e3ef85f8b8be",
-                "sha256:5121d8cf0eacb16133501455d216bb5f99899ae2f52d394fe45d59229e6611d0",
-                "sha256:51f30da7a52c009667e02f125737229d7d8044ad84b79db454308033a7808ab2",
-                "sha256:51fe93f3fe4f5d8483d51072fddc65e717a175490804e1942c975a68e04bf97a",
-                "sha256:57b6e8789cbefdef0667e4a94f8ffa40f9402cee5fc3b8e4274c894737890145",
-                "sha256:590bdba9445df4763bdbebc928d8182f094c1f3947a8dc0fc82ef014dbdd8324",
-                "sha256:5ba9a8770effec5baaaab1567be916c87d8eea0c9ad11253722d86874d885eca",
-                "sha256:607f82389f0ecafc565813aa201a5cade04f897603750028dd660fb01797265e",
-                "sha256:6b4ba0f488c1bdb6bd9ba81da50715a372119785458831c73428a8566253b86b",
-                "sha256:6b7dc7f0a75a7eaa4584e5843c873c561b12602439d2351ee28c7478186c4da4",
-                "sha256:7092cc82382e634075cc0255b0b69cb7cada7c1f249070ace6a95cb0f13548ef",
-                "sha256:7718060dd4434cc719803a5e526838a5d66e4efa5dc46d2b25c21965a9c6fcc4",
-                "sha256:780f750a25e7749d0af6b3631759c2c14f45de209f3faaa2398312d1c7a22759",
-                "sha256:7f39edd52c23e5c7ed94e0e4bf088928029edf86ef10b95413e5ea670c5e92d7",
-                "sha256:80b9ccd82e30038b61fc9a692a8dc4801504689651b281ed9109f10cc9fe8b4d",
-                "sha256:85b22a9cce00cb03156334da67eb86e29f22b5e93876d0dd6a98646bb8a74e53",
-                "sha256:871ebe8143da284bd77b84a9136200bd638be253618765d21a1fce71006d94af",
-                "sha256:89ec0ffc215c590c732918c95cd02b55c7d0f569d76b90bb1a5e78aa340618e4",
-                "sha256:924563481c27941229cb4e16eefacc35da28563e80791b3ddc5597b062a5c386",
-                "sha256:97b6983a2f9c76d345ca395e843a049390b39652984e4a3b45b2442fa733992d",
-                "sha256:991196702d5e0b120a8fef2664e1b9c333a81d36d5f6bcf6b225c0cf8b0451a2",
-                "sha256:998c4751dabf7d29b30594af416e4bf5091f11f92a8d88eb1512c7ba136d1ed7",
-                "sha256:9b2df80cb6a2af86d300e70acb82e9b79dab2c1e6971e44b78dbfc1a1e736b53",
-                "sha256:9d6f494c307e5cb9b1e052ec1a471060f1dea092c8116e642e7a23e79d9388ea",
-                "sha256:9eb245a8d8dd0ad73b4062135a251ec55086fbc2c42e0eb9725a9b553fba18a3",
-                "sha256:a22c3bfe09f7a530e2c94c87ff7af867259c91bef87ed2089cd69b783af7b84e",
-                "sha256:aa309df995d020f3438407081b51ff527171cca6772b33cf8f85344b8b4b8770",
-                "sha256:ab6e19b684981d0cd968906e293d5628e89faacb27977c92f3600b201926b994",
-                "sha256:ac0c5bba938879c2fc0bc6c1b47311b5ad1212a9dcb8b40fe2c8110239b7faed",
-                "sha256:ae2b4856f29ddfe827106794f3589949a57da6f0d38ab01e24ec35107979ba57",
-                "sha256:ae8e59e5f4fd85d6ad34c2bb9d74037b5b11be072b8b7e9986beb11f957573d4",
-                "sha256:b2f22102197bcb1722691296f9e589f02b616f874e54a209284dd7b9294b0b7f",
-                "sha256:b45e2f9d5b0b5c1977cb4feb5f594be60eb121106f8900348e29331f553a726f",
-                "sha256:bc265a7945e8d08da28999ad02b544963f813a00f3ed0a7a0ce4165fd77629f8",
-                "sha256:bed4a2341b33cd1a7d9ffc47df4a78ee61d3416d43b4adc9e18b7d266650b83e",
-                "sha256:c1a40c486041006b135759f59189385da7c66d239bad897c994e18fd1d0c128f",
-                "sha256:c36baa0ecde742784aa76c2b816466d3ea888d5297fda0edbac1bf48fa94688a",
-                "sha256:c4c746d11c8aba4b9f58ca8bfc6fbfd0da4efe7960ae5540d1a1b13655ee8892",
-                "sha256:ca79146ee421b259f8131f153102220b84d1a5e6fb9c8aed13b3badfd1796de6",
-                "sha256:cc452481e124a819ced0c25412ea2e144269ef2f2534b862d9f6a9dae4bda17b",
-                "sha256:cfb8b9d8855c8608f9747602a48ab525b1d320ecf0113994f6df23160af68262",
-                "sha256:d12b15a8c3759e2bb580ffa423ae54be4f184cf23beffcbd641f4fe6e1584293",
-                "sha256:d24fb3c0c8ff0d517c5ca5de7cf3994a4cd559cde0315201511dbfa7ab528894",
-                "sha256:d4b0aab55ad60ead26159ff12b538c85fbab731a5e3411c642b46c3525863437",
-                "sha256:d6a558c2725bfb6337bf57c1cd366c13798bfd3bfc9e3dd1f4a6f6fc95a4605f",
-                "sha256:d946a0c067aa88be4a593aad1236493313bafaa27e2a2080bfe88db827972f3c",
-                "sha256:dc60ddd483c556590da1d9482a4518292eec36dd0e1e8496966759a1f282bcd0",
-                "sha256:dcc93488c9ebd229be6ee1f0d9aad90da97b33ad7e2912f5495804d78a3cd6b7",
-                "sha256:ddca1e4f5f4c67980533df01430184c19b5359900e080248bbf4ed6789584d8b",
-                "sha256:ddf2a63b91399a1c2f88f40bc1705d5a7777e31c7e9eb27c602280f477b582ba",
-                "sha256:df1c742ca6f46a6f6cbcaef9ac694dc2cb1260d30a6a2f5c68c5f5bcfee1cfd7",
-                "sha256:e37c72eaccdd5ed1130c67a92ad38f5b2af66eeff7b0abe29534225db2ef7b18",
-                "sha256:e58991a2b213417285ec866d3cd32db17a6a88061a985dbb7e8e8f13af429c47",
-                "sha256:e6150d167f32f2a54690e572e0a4c90296fb000a18e9b26ab81a6489e24e78dd",
-                "sha256:e88dd71e4ecbc49d9d57d064117462c43f40a21a1383507811cf834a4a620651",
-                "sha256:e8ab8e4c7ec7f8a55ac05b5b715a051d74eac62511c6d96d5bb79aaafa3b04cf",
-                "sha256:ebb08d0867c5a25dffa4823377292a0ffd7aaafb218b5d4e2e106378b1061e39",
-                "sha256:ed3718c757c82d920f1c94089066225ca2ad7f00bb904cb72b1c39ebdd906ccb",
-                "sha256:ee6be07af68d9c4fca4027c70cea0c31a0f1bc9cb464ff3c84a1f916bf82e652",
-                "sha256:efa23166da3fe2915f8ab452dde40319ac84dc357f635737174a08dbd912980c",
-                "sha256:f32a95a83c2e17422f67af922a89422cd24c6fa94041f083dd0bb4f6057d0bc7",
-                "sha256:f7da31a1ba31f1c1d4d5044b7c5813878adae1f3af8f4052d679cc493c7328f4",
-                "sha256:fa2a258aa6bf188eb9a8948f7102a83da7c430a0dce918dbd8b60ef8fcb772d7",
-                "sha256:fc0e46d86905ddd16b85991f1f4919028092b4e511689bbdaff0876bd8aab3dd",
-                "sha256:fefe31d61d02a8b2c419700b1fade9784a43d726de26495f243b663cd9fe1513"
+                "sha256:0100b19f230df72c90fdb36db59d3f39232391e8d89616a7de30f677da4f532b",
+                "sha256:04c74f9ef1f925456a9fd23a7eef1103126186d0500ef9a0acb0bd2514bdc7cc",
+                "sha256:069b779d03d458602bc0e27189876e7d8bdf6b24ac0f12900de22dd2154e6ad7",
+                "sha256:11333094c1bff621aa811b67ed794865cbcaa99984dedea4bd9cf780ad64ecba",
+                "sha256:12e52b5aa00aa720097d6947d2eb9e404e7c1101ad775f9661ba165ed0a28303",
+                "sha256:14fb5b6641ab5b3c4161572579f0f2ea8834f9d3af2f7dd8fbaecd58ef9175cc",
+                "sha256:164429decd0d6b39a0582eaa30c67bf482612c0330572343042d0ed9e7f15c20",
+                "sha256:1a2e934e9da26341d342d30bfe91422bbfdb3f1f069ec87f19b2909d10d8dcc4",
+                "sha256:20f405188d28da9522b7232e51154e1b884fc18d0b3a10f382d54784715bbe01",
+                "sha256:228946da741558904e2c03ce870ba5efd9cd6e48cbc004d9a27abee08100a15a",
+                "sha256:22aca3e691c7709c5999ccf48b7a8ff5cf5a8bd6fe9b36efbd4993f5a36b2fcf",
+                "sha256:248b5394718e10d067354448dc406d651709c6765669679311170da18e0e9af8",
+                "sha256:2c3b210d79925a476dfc8d74c7d53224888421edebf3a611f3adae923e212b27",
+                "sha256:2d358f259d8019d4ef25d8c5b78aca4c7af25e28bd4231312911c22a0e824a57",
+                "sha256:2e980e4179f33d9b65ac4acb86c9c0dde904098853f27f289766657ed16e07b3",
+                "sha256:38fd1ccfca7838c031d7a7874d4353e2f1b98eb5d2a80a2fe5732d542ae25e9c",
+                "sha256:3b990df23dd51dccce26d18fb09fd85a77ebe46368f387b0ffba7a74e470b31b",
+                "sha256:3f37516458ec1550815134937f73d6d15b434059cd10f64678a2068f65c62406",
+                "sha256:44329cbed24966c0b49acb386352c9722219af1f0c80db7f218af7793d251902",
+                "sha256:4c2de4cb80b9990e71c62c2d3e9f3ec71b804b1f9ca4784ec7e74127e0f42468",
+                "sha256:5250bda76e30382e0a2dcd68d961afcab92c3a7613606e6269855c6979a1b0bb",
+                "sha256:52d708b5fd65589461381fa442d9905f5903d76c086c6a4108e8e9efdca7a7ed",
+                "sha256:5b9d538e8e04916a5df63052d698b30c74eb0174f2ca9cd942c981f274a18eaf",
+                "sha256:5c61675a922b569137cf943770d7ad3edd0202d992ce53ac328c5ff68213ccf4",
+                "sha256:5d6e6d84e6dd31a8ded64759626627247d676a23c1b892e1326f7c55c8d61055",
+                "sha256:64586ce42bbe0da4d9f76f97235c545d1abb9b25985a8791857690f96e23dc3b",
+                "sha256:651015dcd5fd9b5a51ca79ece60d353cacc5beaf304db750407b29c89f72fe2b",
+                "sha256:65b451949cb789c346f9f9002441fc934d8ccedcc9ec09daabc2139ad13853f7",
+                "sha256:6c031da749a05f7a01447dd7f47beedb498edd293e31e1878c0d52db18787df0",
+                "sha256:6eb586fa7d2aee8d65d5ae1dd71414020b2f447435c57ee8de8abea0a77d5074",
+                "sha256:6f0cbe5f7dd19f3a32bac2251b95d51c3b89621ac88a2648096ce40f9a5aa1e7",
+                "sha256:718044729bf1fe3e9eb9f31b52e44ddae07e434ec050c8c628bf5adc56fe4bdd",
+                "sha256:71d40b3ac0f26fa9ffa6ee16219a714fed5c6ec197cdcd2018904ab5e75bcfa3",
+                "sha256:75bf7ab2374a7eb107602f1e07310cda164016cd60968abf817b7a0b5703e288",
+                "sha256:75cc1a3f8c88c69bf16a871dab1fe5a7303fdb1e9f285f204b60f1ee539b8fc0",
+                "sha256:765b13b164685a2f8b2abef867ad07aebedc0e090c757958a186f64e39d63dbd",
+                "sha256:76c1ffaaf4f6f0f6e8e9ca06f24bb6454a7a5d4ced97a1bc466f0d6baf4bd518",
+                "sha256:79f0283ab5e6499fd5fe382ca3d62afa40fb50ff227676a3125d18af70eabf65",
+                "sha256:7f10ca4cde7b466405cce0a0e9971a13eb22e57a5ecc8b5f93a81090cc9c7eb9",
+                "sha256:81bf6a32212f9f66da03d63ecb9cd9bd48e662050a937db7199dbf47d19831de",
+                "sha256:835f39e618099325e7612b3406f57af30ab0a0af350490eff6421e2e5f608e46",
+                "sha256:86da8a3a84b79ead5c7d0e960c34f580bc3b231bb546627773a3f53c532c2f21",
+                "sha256:890ad3a26da9ec7bf69255b9371800e2a8da9bc223ae5d86daeb940b42247c83",
+                "sha256:8f34b09f68bdadec122ffad312154eda965ade433559cc1eadd96cca3de5c824",
+                "sha256:916369b3b914186b2c5e5ad2f7264b02cff5df96cdd7cdad65dccd39aa5fd9f0",
+                "sha256:95db3750dd2e6e93d99fa2498f3a1580581e49c494bddccc6f85c5c21604921f",
+                "sha256:95e23987b52d02e7c413bf2d6dc6288bd5721beb518052109a13bfdc62c8033b",
+                "sha256:96e5921342574a14303dfdb73de0019e1ac041c863743c8fe1aa6c2b4a257226",
+                "sha256:98a838101321ac3089c9bb1d4bfa967e8afed58021fda72d7880dc1997f20ae1",
+                "sha256:99cef9731c8a39801830a604cc53c93c9e57ea8b44953d26589499eded9576e0",
+                "sha256:99d16f15cb5baf0729354c5bd3080ae53847a4072b9ba1e10957522fb290417f",
+                "sha256:9bdff88e858ee608a924acfad32a180d2bf6e13e059d6a7174abbae075f30436",
+                "sha256:9c1cd71483ea78331bdfadb8dcec4f4edfb73c7002c1206d8e0af6797853f5be",
+                "sha256:9dd37e9ac00d5eb72f38ed93e3cdf2280b1dbda3bb9b48c6941805f265ad8d87",
+                "sha256:9f75dbf4899e29a37d74f48342f29279391668ef625fdac6d2f67363518056a1",
+                "sha256:a219b70100500d0c7fd3ebb824a3302efb6b1a122baa9d4eb3f43df8f0b3d899",
+                "sha256:a3e853cc04987c85ec410905667eed4bf08b1d84d80dfab2684bb250ac8da4f6",
+                "sha256:a7df481e7508de1c38b9b8043da48d94931aefa3e32b47dd20277e4978ed5b95",
+                "sha256:a91e027d66eff214d88d9afbe528e21c9ef1ecdf4956c46e366c50f3094696d0",
+                "sha256:abb57fdd38bf6f7dcc66b38dafb7af7c5fdc31ac6029ce373a6f7f5331d6f60f",
+                "sha256:aca7b5645afa688de6d4f8e89d30c577f62956fefb1bad021490d63173874186",
+                "sha256:adda2268b8cf0d11f160fad3743b4dfe9813cd6ecf02c1d6397eceaa5b45b388",
+                "sha256:ae385e1d58fbc6a9b1c315e5510ac52281e271478b45f92ca9b5ad42cf39643f",
+                "sha256:bc2e69b795d97ee6d126e7e22e78a509438b46be6ff44f4dccbb5230f550d340",
+                "sha256:bc3945b7bad33957a9eca16e9e5eae4b17cb03173ef594fdaad228f4fc7da53b",
+                "sha256:be127f292496d0fbe20d8025f73221b36117b3587f890346e80a13b310712982",
+                "sha256:bf67d1787cd317c3f8b2e4c6ed1ae93497be7e30605a0d32237ac37a37a8a322",
+                "sha256:c2e117e64c26300032755d4520cd769f2623cde1a1d1c3515b05a3b8add0ade1",
+                "sha256:c7195444b932356055a8e287fa910bf9753a84a1bc33aeb3770e8fca521e032e",
+                "sha256:ca07fa78cc9d26bc8c4740de1abd3489cf9c47cc06d9a8ab3d552ff5101af4c0",
+                "sha256:cc3902584d25c7eef57fb38f440aa849a26a3a9f761a029a72b69acfca4e31f8",
+                "sha256:d800705f6951f75a905ea6feb03fff8f3ea3468b81e7563373ddc29aa3e5d1ca",
+                "sha256:d8f2d83118f25328552c728b8e91babf93217db259ca5c2cd4dd4220b8926293",
+                "sha256:daaf98009977f577b71f8800208f4d40d4dcf5c2db53d4d822787cdc198d76e1",
+                "sha256:de3c6271c482c250d3303fb5c6bdb8ca025fff20a67245e1425df04dc990ece9",
+                "sha256:e33e79a219105aa315439ee051bd50b6caa705dc4164a5aba6932c8ac3ce2d98",
+                "sha256:e4545e906f595ee8ab8e03e21be20d899bfc06647925bc5b224ad7e8c40e08b8",
+                "sha256:e4f5f1320f8ee0d7cfa421ceb257bef9d39fd614dd3ddcfcacd284d4824ed2c2",
+                "sha256:e8415918856a3e7d57a4e0ad94651b761317de459eb74d34cc1bb51aad80f07e",
+                "sha256:e96649ac34a3d0e6491e82a2af71098e43be2874b619547c3282fc11d3840a4b",
+                "sha256:ea58b112f2966a8b91eb13f5d3b1f8bb43c180d624cd3283fb33b1cedcc2dd75",
+                "sha256:ea8d8fe546c528535c761ba424410bbeb36ba8a0f24be653e94b70c93fd8a8ca",
+                "sha256:f256173b48cc68486299d510a3e729a96e62c889703807482dbf56946befb5c8",
+                "sha256:f287a25a8ca53901c613498e4a40885b19361a2fe8fbfdbb7f8ef2cad2a23f03",
+                "sha256:f2a79145a531a0e42df32d37be5af069b4a914845b6f686590739b786f2f7bce",
+                "sha256:f35481d42c6d146d48ec92d4e239c23f97b53a3f1fbd2302e7c64336f28641fe",
+                "sha256:fd17f427f041f6b116dc90b4049c6f3e1230524407d00daa2d8c7915037b5947",
+                "sha256:fe024d40ac31eb8d5aae70215b41dafa264676caa4404ae155f77d2fa95c37bb"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==7.10.1"
+            "version": "==7.10.2"
         },
         "coveralls": {
             "hashes": [
@@ -710,7 +703,6 @@
                 "sha256:7b2a0a2bcef94f295e3cf28dcc55ca40b71c77d1c2446b538e85f0f7bc21aa69"
             ],
             "index": "pypi",
-            "markers": "python_version < '3.13' and python_version >= '3.8'",
             "version": "==4.0.1"
         },
         "cryptography": {
@@ -839,7 +831,6 @@
                 "sha256:c033c6d4e7914c3d9768aabe76bbe87ba1dc66a92a05db6bfa1125d81f2ee270"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.11'",
             "version": "==9.4.0"
         },
         "ipython-pygments-lexers": {
@@ -979,7 +970,6 @@
                 "sha256:e9ba7e4764a6088ccc34e3cc846ae719861ca202409fa865573de40a3e805b9b"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==5.1.9"
         },
         "msgpack": {
@@ -1089,7 +1079,6 @@
                 "sha256:ff2933428516ab63f961644bc49bc4cbe42bbffb2cd3b71cc7277c07d16b1a8b"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==1.17.1"
         },
         "mypy-boto3-cloudformation": {
@@ -1241,7 +1230,7 @@
                 "sha256:fc927d7f289d14f5e037be917539620603294454130b6de200091e23d27dc9be",
                 "sha256:fed5527c4cf10f16c6d0b6bee1f89958bccb0ad2522c8cadc2efd318bcd545f5"
             ],
-            "markers": "python_version >= '3.11'",
+            "markers": "python_version >= '3.12'",
             "version": "==2.3.2"
         },
         "packageurl-python": {
@@ -1266,7 +1255,6 @@
                 "sha256:fb6a8478327b16ed65c46b1541de74f5c5947f3601850caf3e885e0140584717"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.10'",
             "version": "==2.3.0.250703"
         },
         "parso": {
@@ -1315,7 +1303,6 @@
                 "sha256:348b16e60895749a0839875d7cc27ebd692e1584ebe5d5cb145941c8e25a80bd"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==2.9.0"
         },
         "pip-requirements-parser": {
@@ -1348,7 +1335,6 @@
                 "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==4.2.0"
         },
         "prompt-toolkit": {
@@ -1428,7 +1414,6 @@
                 "sha256:fee33b0ca46f4c85443d6c450357101e47d53e6c3f008d658c27a2d020d44c79"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==21.0.0"
         },
         "pyarrow-stubs": {
@@ -1437,7 +1422,6 @@
                 "sha256:8fa8a93a7b7ec3c8d6df8c452628f4351419e8bc44ac45a298d7223d05dcdd0a"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9' and python_version < '4'",
             "version": "==20.0.0.20250716"
         },
         "pycparser": {
@@ -1470,7 +1454,6 @@
                 "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==8.4.1"
         },
         "pytest-mock": {
@@ -1479,7 +1462,6 @@
                 "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==3.14.1"
         },
         "python-dateutil": {
@@ -1487,7 +1469,7 @@
                 "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
                 "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9.0.post0"
         },
         "pyyaml": {
@@ -1595,7 +1577,6 @@
                 "sha256:e41df94a957d50083fd09b916d6e89e497246698c3f3d5c681c8b3e7b9bb4ac8"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==0.12.7"
         },
         "s3transfer": {
@@ -1612,7 +1593,6 @@
                 "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==80.9.0"
         },
         "six": {
@@ -1620,7 +1600,7 @@
                 "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
                 "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.17.0"
         },
         "sortedcontainers": {
@@ -1642,7 +1622,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "traitlets": {
@@ -1690,16 +1670,16 @@
                 "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760",
                 "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"
             ],
-            "markers": "python_version >= '3.9'",
+            "markers": "python_version >= '3.10'",
             "version": "==2.5.0"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:2c310aecb62e5aa1b06103ed7c2977b81e042695de2697d01017ff0f1034af56",
-                "sha256:886bf75cadfdc964674e6e33eb74d787dff31ca314ceace03ca5810620f4ecf0"
+                "sha256:106b6baa8ab1b526d5a9b71165c85c456fbd49b16976c88e2bc9352ee3bc5d3f",
+                "sha256:47e0c0d2ef1801fce721708ccdf2a28b9403fa2307c3268aebd03225976f61d2"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==20.32.0"
+            "version": "==20.33.0"
         },
         "wcwidth": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -49,7 +49,16 @@ WARNING_ONLY_LOGGERS=# Comma-seperated list of logger names to set as WARNING on
 MINIO_S3_ENDPOINT_URL=# If set, informs the library to use this Minio S3 instance.  Requires the http(s):// protocol. 
 MINIO_USERNAME=# Username / AWS Key for Minio; required when MINIO_S3_ENDPOINT_URL is set
 MINIO_PASSWORD=# Pasword / AWS Secret for Minio; required when MINIO_S3_ENDPOINT_URL is set
-MINIO_DATA=# Path to persist MinIO data if started via Makefile command 
+MINIO_DATA=# Path to persist MinIO data if started via Makefile command
+
+TDA_READ_BATCH_SIZE=# Row size of batches read, affecting memory consumption
+TDA_WRITE_BATCH_SIZE=# Row size of batches written, directly affecting row group size in final parquet files
+TDA_MAX_ROWS_PER_GROUP=# Max number of rows per row group in a parquet file
+TDA_MAX_ROWS_PER_FILE=# Max number of rows in a single parquet file
+TDA_BATCH_READ_AHEAD=# Number of batches to optimistically read ahead when batch reading from a dataset; pyarrow default is 16
+TDA_FRAGMENT_READ_AHEAD=# Number of fragments to optimistically read ahead when batch reaching from a dataset; pyarrow default is 4
+TDA_DUCKDB_MEMORY_LIMIT=# Memory limit for DuckDB connection
+TDA_DUCKDB_THREADS=# Thread limit for DuckDB connection
 ```
 
 ## Local S3 via MinIO

--- a/timdex_dataset_api/utils.py
+++ b/timdex_dataset_api/utils.py
@@ -6,7 +6,6 @@ import pathlib
 from urllib.parse import urlparse
 
 import boto3
-from duckdb import DuckDBPyConnection
 from mypy_boto3_s3.service_resource import S3ServiceResource
 
 logger = logging.getLogger(__name__)
@@ -85,45 +84,3 @@ class S3Client:
         bucket = parsed.netloc
         key = parsed.path.lstrip("/")  # strip leading slash from /key
         return bucket, key
-
-
-def configure_duckdb_s3_secret(
-    conn: DuckDBPyConnection,
-    scope: str | None = None,
-) -> None:
-    """Configure a secret in a DuckDB connection for S3 access.
-
-    If a scope is provided, e.g. an S3 URI prefix like 's3://timdex', set a scope
-    parameter in the config.  Else, leave it blank.
-    """
-    # establish scope string
-    scope_str = f", scope '{scope}'" if scope else ""
-
-    if os.getenv("MINIO_S3_ENDPOINT_URL"):
-        conn.execute(
-            f"""
-            create or replace secret minio_s3_secret (
-                type s3,
-                endpoint '{urlparse(os.environ["MINIO_S3_ENDPOINT_URL"]).netloc}',
-                key_id '{os.environ["MINIO_USERNAME"]}',
-                secret '{os.environ["MINIO_PASSWORD"]}',
-                region 'us-east-1',
-                url_style 'path',
-                use_ssl false
-                {scope_str}
-            );
-            """
-        )
-
-    else:
-        conn.execute(
-            f"""
-            create or replace secret aws_s3_secret (
-                type s3,
-                provider credential_chain,
-                chain 'sso;env;config',
-                refresh auto
-                {scope_str}
-            );
-            """
-        )


### PR DESCRIPTION
### Purpose and background context

This PR begins to write [append deltas](https://mitlibraries.atlassian.net/wiki/spaces/D/pages/4700962824/Managed+ETL+Dataset+Metadata#Append-Deltas) during all ETL records data writes.

This is achieved by a small hook in `TIMDEXDataset.write()` that calls `TIMDEXDatasetMetadata.write_append_delta_duckdb()` for each ETL parquet file that was created.

`TIMDEXDatasetMetadata.write_append_delta_duckdb()` performs the work entirely in a DuckDB context by retrieving metadata from the ETL parquet file written, then writing a new append delta parquet file.

As with most of the PRs in epic [TIMX-515](https://mitlibraries.atlassian.net/browse/TIMX-515), there is a bit of required alignment, cleanup, and updates as the changes are implemented, including:

- addition of methods `TIMDEXDataset.create_data_structure()` and `TIMDEXDatasetMetadata.create_metadata_structure()`
  - provide _one_ place to ensure the dataset has the required structure for new files
- `TIMDEXDatasetMetadata.configure_duckdb_connection()`
  - continue to refine the important and highly used DuckDB connection on the `TIMDEXDatasetMetadata` instance

#### Next steps:

- Create metadata projections over static DB file and append deltas, [TIMX-526](https://mitlibraries.atlassian.net/browse/TIMX-526)
- Fully rework `TIMDEXDataset.load()` and dataset "location", [TIMX-533](https://mitlibraries.atlassian.net/browse/TIMX-533)
- Rework read methods to use SQL + metadata, [TIMX-529](https://mitlibraries.atlassian.net/browse/TIMX-529)
- Merge append deltas into static DB, [TIMX-528](https://mitlibraries.atlassian.net/browse/TIMX-528)

### How can a reviewer manually see the effects of these changes?

1- Set AWS Dev `TimdexManagers` credentials

2- Set env vars:
```shell
TDA_LOG_LEVEL=DEBUG
WARNING_ONLY_LOGGERS=asyncio,botocore,urllib3,s3transfer,boto3,MARKDOWN
TIMDEX_DATASET_LOCATION=s3://timdex-extract-dev-222053980223/dataset_scratch
```

3- Start Ipython shell with `pipenv run ipython` and do some setup:
```python
import os

from timdex_dataset_api import TIMDEXDataset
from timdex_dataset_api.config import configure_dev_logger
from tests.utils import generate_sample_records

configure_dev_logger()

td = TIMDEXDataset(os.environ["TIMDEX_DATASET_LOCATION"])
```

Note that already we're  back to using `TIMDEXDataset`.  It's expected we will rarely need to use `TIMDEXDatasetMetadata` directly as it becomes increasingly integrated with `TIMDEXDataset` functionality.

4- Perform a write operation and note the logged output:
```python
written_files = td.write(generate_sample_records(num_records=1000))

"""
DEBUG:timdex_dataset_api.dataset:Yielding batch 1 for dataset writing.
DEBUG:timdex_dataset_api.metadata:Append delta written: s3://timdex-extract-dev-222053980223/dataset_scratch/metadata/append_deltas/append_delta-2903e4f0-5a7b-4010-a48c-38611200c1c9-0.parquet, 0.9079843750223517s
INFO:timdex_dataset_api.dataset:Dataset write complete - elapsed: 2.49s, total files: 1, total rows: 1000, total size: 13883
"""
```

### Includes new or updated dependencies?
YES

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-527

[TIMX-515]: https://mitlibraries.atlassian.net/browse/TIMX-515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TIMX-526]: https://mitlibraries.atlassian.net/browse/TIMX-526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TIMX-527]: https://mitlibraries.atlassian.net/browse/TIMX-527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ