### PR TITLE
TIMX 526 - projected views

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -36,7 +36,7 @@ def test_dataset_init_success(
     location_param,
     expected_file_system,
     expected_source_param,
-    mocked_timdex_bucket,
+    s3_bucket_mocked,
     tmp_path,
 ):
     location = location_param
@@ -51,21 +51,23 @@ def test_dataset_init_success(
     assert timdex_dataset.paths == expected_source
 
 
-def test_dataset_init_env_vars_set_config(monkeypatch, local_dataset_location):
-    default_timdex_dataset = TIMDEXDataset(location=local_dataset_location)
+def test_dataset_init_env_vars_set_config(monkeypatch, tmp_path):
+    location = str(tmp_path / "timdex_dataset/")
+    default_timdex_dataset = TIMDEXDataset(location=location)
     default_read_batch_config = default_timdex_dataset.config.read_batch_size
     assert default_read_batch_config == 1_000
 
     monkeypatch.setenv("TDA_READ_BATCH_SIZE", "100_000")
-    env_var_timdex_dataset = TIMDEXDataset(location=local_dataset_location)
+    env_var_timdex_dataset = TIMDEXDataset(location=location)
     env_var_read_batch_config = env_var_timdex_dataset.config.read_batch_size
     assert env_var_read_batch_config == 100_000
 
 
-def test_dataset_init_custom_config_object(monkeypatch, local_dataset_location):
+def test_dataset_init_custom_config_object(monkeypatch, tmp_path):
+    location = str(tmp_path / "timdex_dataset/")
     config = TIMDEXDatasetConfig()
     config.max_rows_per_file = 42
-    timdex_dataset = TIMDEXDataset(location=local_dataset_location, config=config)
+    timdex_dataset = TIMDEXDataset(location=location, config=config)
     assert timdex_dataset.config.max_rows_per_file == 42
 
 
@@ -97,7 +99,7 @@ def test_dataset_load_local_sets_filesystem_and_dataset_success(
 @patch("timdex_dataset_api.dataset.TIMDEXDataset.get_s3_filesystem")
 @patch("timdex_dataset_api.dataset.ds.dataset")
 def test_dataset_load_s3_sets_filesystem_and_dataset_success(
-    mock_pyarrow_ds, mock_get_s3_fs, mocked_timdex_bucket
+    mock_pyarrow_ds, mock_get_s3_fs, s3_bucket_mocked
 ):
     mock_get_s3_fs.return_value = MagicMock()
     mock_pyarrow_ds.return_value = MagicMock()
@@ -116,42 +118,46 @@ def test_dataset_load_s3_sets_filesystem_and_dataset_success(
     assert result is None
 
 
-def test_dataset_load_without_filters_success(fixed_local_dataset):
-    fixed_local_dataset.load()
+def test_dataset_load_without_filters_success(timdex_dataset_multi_source):
+    timdex_dataset_multi_source.load()
 
-    assert os.path.exists(fixed_local_dataset.location)
-    assert fixed_local_dataset.row_count == 5_000
-
-
-def test_dataset_load_with_run_date_str_filters_success(fixed_local_dataset):
-    fixed_local_dataset.load(run_date="2024-12-01")
-
-    assert os.path.exists(fixed_local_dataset.location)
-    assert fixed_local_dataset.row_count == 5_000
+    assert os.path.exists(timdex_dataset_multi_source.location)
+    assert timdex_dataset_multi_source.row_count == 5_000
 
 
-def test_dataset_load_with_run_date_obj_filters_success(fixed_local_dataset):
-    fixed_local_dataset.load(run_date=date(2024, 12, 1))
+def test_dataset_load_with_run_date_str_filters_success(timdex_dataset_multi_source):
+    timdex_dataset_multi_source.load(run_date="2024-12-01")
 
-    assert os.path.exists(fixed_local_dataset.location)
-    assert fixed_local_dataset.row_count == 5_000
-
-
-def test_dataset_load_with_ymd_filters_success(fixed_local_dataset):
-    fixed_local_dataset.load(year="2024", month="12", day="01")
-
-    assert os.path.exists(fixed_local_dataset.location)
-    assert fixed_local_dataset.row_count == 5_000
+    assert os.path.exists(timdex_dataset_multi_source.location)
+    assert timdex_dataset_multi_source.row_count == 5_000
 
 
-def test_dataset_load_with_single_nonpartition_filters_success(fixed_local_dataset):
-    fixed_local_dataset.load(timdex_record_id="alma:0")
+def test_dataset_load_with_run_date_obj_filters_success(timdex_dataset_multi_source):
+    timdex_dataset_multi_source.load(run_date=date(2024, 12, 1))
 
-    assert fixed_local_dataset.row_count == 1
+    assert os.path.exists(timdex_dataset_multi_source.location)
+    assert timdex_dataset_multi_source.row_count == 5_000
 
 
-def test_dataset_load_with_multi_nonpartition_filters_success(fixed_local_dataset):
-    fixed_local_dataset.load(
+def test_dataset_load_with_ymd_filters_success(timdex_dataset_multi_source):
+    timdex_dataset_multi_source.load(year="2024", month="12", day="01")
+
+    assert os.path.exists(timdex_dataset_multi_source.location)
+    assert timdex_dataset_multi_source.row_count == 5_000
+
+
+def test_dataset_load_with_single_nonpartition_filters_success(
+    timdex_dataset_multi_source,
+):
+    timdex_dataset_multi_source.load(timdex_record_id="alma:0")
+
+    assert timdex_dataset_multi_source.row_count == 1
+
+
+def test_dataset_load_with_multi_nonpartition_filters_success(
+    timdex_dataset_multi_source,
+):
+    timdex_dataset_multi_source.load(
         timdex_record_id="alma:0",
         source="alma",
         run_type="daily",
@@ -159,12 +165,14 @@ def test_dataset_load_with_multi_nonpartition_filters_success(fixed_local_datase
         action="index",
     )
 
-    assert fixed_local_dataset.row_count == 1
+    assert timdex_dataset_multi_source.row_count == 1
 
 
 @pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
-def test_dataset_load_current_records_all_sources_success(dataset_with_runs_location):
-    timdex_dataset = TIMDEXDataset(dataset_with_runs_location)
+def test_dataset_load_current_records_all_sources_success(
+    timdex_timdex_dataset_with_runs,
+):
+    timdex_dataset = TIMDEXDataset(timdex_timdex_dataset_with_runs.location)
 
     # 16 total parquet files, with current_records=False we get them all
     timdex_dataset.load(current_records=False)
@@ -176,8 +184,8 @@ def test_dataset_load_current_records_all_sources_success(dataset_with_runs_loca
 
 
 @pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
-def test_dataset_load_current_records_one_source_success(dataset_with_runs_location):
-    timdex_dataset = TIMDEXDataset(dataset_with_runs_location)
+def test_dataset_load_current_records_one_source_success(timdex_timdex_dataset_with_runs):
+    timdex_dataset = TIMDEXDataset(timdex_timdex_dataset_with_runs.location)
     timdex_dataset.load(current_records=True, source="alma")
 
     # 7 total parquet files for source, only 6 related to current runs
@@ -185,98 +193,106 @@ def test_dataset_load_current_records_one_source_success(dataset_with_runs_locat
 
 
 def test_dataset_get_filtered_dataset_with_single_nonpartition_success(
-    fixed_local_dataset,
+    timdex_dataset_multi_source,
 ):
-    fixed_local_dataset.load()  # initial load dataset, no filters passed
+    timdex_dataset_multi_source.load()  # initial load dataset, no filters passed
 
-    filtered_local_dataset = fixed_local_dataset._get_filtered_dataset(
+    filtered_timdex_dataset = timdex_dataset_multi_source._get_filtered_dataset(
         run_id="abc123",
     )
-    filtered_local_df = filtered_local_dataset.to_table().to_pandas()
+    filtered_local_df = filtered_timdex_dataset.to_table().to_pandas()
 
-    # fixed_local_dataset consists of single 'run_id' value
-    # therefore, filtered_local_dataset includes all records
-    assert len(filtered_local_df) == filtered_local_dataset.count_rows()
+    # timdex_dataset_multi_source consists of single 'run_id' value
+    # therefore, filtered_timdex_dataset includes all records
+    assert len(filtered_local_df) == filtered_timdex_dataset.count_rows()
     assert filtered_local_df["run_id"].unique() == ["abc123"]
 
 
 def test_dataset_get_filtered_dataset_with_multi_nonpartition_filters_success(
-    fixed_local_dataset,
+    timdex_dataset_multi_source,
 ):
-    fixed_local_dataset.load()  # initial load dataset, no filters passed
+    timdex_dataset_multi_source.load()  # initial load dataset, no filters passed
 
-    filtered_local_dataset = fixed_local_dataset._get_filtered_dataset(
+    filtered_timdex_dataset = timdex_dataset_multi_source._get_filtered_dataset(
         timdex_record_id="alma:0",
         source="alma",
         run_type="daily",
         run_id="abc123",
         action="index",
     )
-    filtered_local_df = filtered_local_dataset.to_table().to_pandas()
+    filtered_local_df = filtered_timdex_dataset.to_table().to_pandas()
 
     assert len(filtered_local_df) == 1
     assert filtered_local_df["timdex_record_id"].iloc[0] == "alma:0"
 
 
 def test_dataset_get_filtered_dataset_with_or_nonpartition_filters_success(
-    fixed_local_dataset,
+    timdex_dataset_multi_source,
 ):
-    fixed_local_dataset.load()
+    timdex_dataset_multi_source.load()
 
-    filtered_local_dataset = fixed_local_dataset._get_filtered_dataset(
+    filtered_timdex_dataset = timdex_dataset_multi_source._get_filtered_dataset(
         timdex_record_id=["alma:0", "alma:1"]
     )
-    filtered_local_df = filtered_local_dataset.to_table().to_pandas()
+    filtered_local_df = filtered_timdex_dataset.to_table().to_pandas()
     assert len(filtered_local_df) == 2
     assert filtered_local_df["timdex_record_id"].tolist() == ["alma:0", "alma:1"]
 
 
-def test_dataset_get_filtered_dataset_with_run_date_str_successs(fixed_local_dataset):
-    fixed_local_dataset.load()  # initial load dataset, no filters passed
+def test_dataset_get_filtered_dataset_with_run_date_str_successs(
+    timdex_dataset_multi_source,
+):
+    timdex_dataset_multi_source.load()  # initial load dataset, no filters passed
 
-    filtered_local_dataset = fixed_local_dataset._get_filtered_dataset(
+    filtered_timdex_dataset = timdex_dataset_multi_source._get_filtered_dataset(
         run_date="2024-12-01"
     )
-    empty_local_dataset = fixed_local_dataset._get_filtered_dataset(run_date="2024-12-02")
+    empty_timdex_dataset = timdex_dataset_multi_source._get_filtered_dataset(
+        run_date="2024-12-02"
+    )
 
-    # fixed_local_dataset consists of single 'run_date' value
-    # therefore, filtered_local_dataset includes all records
-    assert filtered_local_dataset.count_rows() == fixed_local_dataset.row_count
-    assert empty_local_dataset.count_rows() == 0
+    # timdex_dataset_multi_source consists of single 'run_date' value
+    # therefore, filtered_timdex_dataset includes all records
+    assert filtered_timdex_dataset.count_rows() == timdex_dataset_multi_source.row_count
+    assert empty_timdex_dataset.count_rows() == 0
 
 
-def test_dataset_get_filtered_dataset_with_run_date_obj_success(fixed_local_dataset):
-    fixed_local_dataset.load()  # initial load dataset, no filters passed
+def test_dataset_get_filtered_dataset_with_run_date_obj_success(
+    timdex_dataset_multi_source,
+):
+    timdex_dataset_multi_source.load()  # initial load dataset, no filters passed
 
-    filtered_local_dataset = fixed_local_dataset._get_filtered_dataset(
+    filtered_timdex_dataset = timdex_dataset_multi_source._get_filtered_dataset(
         run_date=date(2024, 12, 1)
     )
-    empty_local_dataset = fixed_local_dataset._get_filtered_dataset(
+    empty_timdex_dataset = timdex_dataset_multi_source._get_filtered_dataset(
         run_date=date(2024, 12, 2)
     )
 
-    # fixed_local_dataset consists of single 'run_date' value
-    # therefore, filtered_local_dataset includes all records
-    assert filtered_local_dataset.count_rows() == fixed_local_dataset.row_count
-    assert empty_local_dataset.count_rows() == 0
+    # timdex_dataset_multi_source consists of single 'run_date' value
+    # therefore, filtered_timdex_dataset includes all records
+    assert filtered_timdex_dataset.count_rows() == timdex_dataset_multi_source.row_count
+    assert empty_timdex_dataset.count_rows() == 0
 
 
-def test_dataset_get_filtered_dataset_with_ymd_success(fixed_local_dataset):
-    fixed_local_dataset.load()  # initial load dataset, no filters passed
+def test_dataset_get_filtered_dataset_with_ymd_success(timdex_dataset_multi_source):
+    timdex_dataset_multi_source.load()  # initial load dataset, no filters passed
 
-    filtered_local_dataset = fixed_local_dataset._get_filtered_dataset(year="2024")
-    empty_local_dataset = fixed_local_dataset._get_filtered_dataset(year="2025")
+    filtered_timdex_dataset = timdex_dataset_multi_source._get_filtered_dataset(
+        year="2024"
+    )
+    empty_timdex_dataset = timdex_dataset_multi_source._get_filtered_dataset(year="2025")
 
-    # fixed_local_dataset consists of single 'run_date' value
-    # therefore, filtered_local_dataset includes all records
-    assert filtered_local_dataset.count_rows() == fixed_local_dataset.row_count
-    assert empty_local_dataset.count_rows() == 0
+    # timdex_dataset_multi_source consists of single 'run_date' value
+    # therefore, filtered_timdex_dataset includes all records
+    assert filtered_timdex_dataset.count_rows() == timdex_dataset_multi_source.row_count
+    assert empty_timdex_dataset.count_rows() == 0
 
 
 def test_dataset_get_filtered_dataset_with_run_date_invalid_raise_error(
-    fixed_local_dataset,
+    timdex_dataset_multi_source,
 ):
-    fixed_local_dataset.load()  # initial load dataset, no filters passed
+    timdex_dataset_multi_source.load()  # initial load dataset, no filters passed
 
     with pytest.raises(
         TypeError,
@@ -285,7 +301,7 @@ def test_dataset_get_filtered_dataset_with_run_date_invalid_raise_error(
             "or a datetime.date."
         ),
     ):
-        _ = fixed_local_dataset._get_filtered_dataset(run_date=999)
+        _ = timdex_dataset_multi_source._get_filtered_dataset(run_date=999)
 
 
 def test_dataset_get_s3_filesystem_success(mocker):
@@ -384,25 +400,25 @@ def test_dataset_parse_location_error(
         _ = TIMDEXDataset.parse_location(location)
 
 
-def test_dataset_local_dataset_validate_success(local_dataset):
-    assert local_dataset.dataset.to_table().validate() is None  # where None is valid
+def test_dataset_timdex_dataset_validate_success(timdex_dataset):
+    assert timdex_dataset.dataset.to_table().validate() is None  # where None is valid
 
 
-def test_dataset_local_dataset_row_count_success(local_dataset):
-    assert local_dataset.dataset.count_rows() == local_dataset.row_count
+def test_dataset_timdex_dataset_row_count_success(timdex_dataset):
+    assert timdex_dataset.dataset.count_rows() == timdex_dataset.row_count
 
 
-def test_dataset_local_dataset_row_count_missing_dataset_raise_error(
-    local_dataset, tmp_path
+def test_dataset_timdex_dataset_row_count_missing_dataset_raise_error(
+    timdex_dataset, tmp_path
 ):
     td = TIMDEXDataset(location=str(tmp_path / "path/to/nowhere"))
     with pytest.raises(DatasetNotLoadedError):
         _ = td.row_count
 
 
-def test_dataset_all_records_not_current_and_not_deduped(dataset_with_runs):
-    dataset_with_runs.load()
-    all_records_df = dataset_with_runs.read_dataframe()
+def test_dataset_all_records_not_current_and_not_deduped(timdex_dataset_with_runs):
+    timdex_dataset_with_runs.load()
+    all_records_df = timdex_dataset_with_runs.read_dataframe()
 
     # assert counts reflect all records from dataset, no deduping
     assert all_records_df.source.value_counts().to_dict() == {"alma": 254, "dspace": 194}
@@ -413,9 +429,9 @@ def test_dataset_all_records_not_current_and_not_deduped(dataset_with_runs):
 
 
 @pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
-def test_dataset_all_current_records_deduped(dataset_with_runs):
-    dataset_with_runs.load(current_records=True)
-    all_records_df = dataset_with_runs.read_dataframe()
+def test_dataset_all_current_records_deduped(timdex_dataset_with_runs):
+    timdex_dataset_with_runs.load(current_records=True)
+    all_records_df = timdex_dataset_with_runs.read_dataframe()
 
     # assert both sources have accurate record counts for current records only
     assert all_records_df.source.value_counts().to_dict() == {"dspace": 90, "alma": 100}
@@ -429,9 +445,9 @@ def test_dataset_all_current_records_deduped(dataset_with_runs):
 
 
 @pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
-def test_dataset_source_current_records_deduped(dataset_with_runs):
-    dataset_with_runs.load(current_records=True, source="alma")
-    alma_records_df = dataset_with_runs.read_dataframe()
+def test_dataset_source_current_records_deduped(timdex_dataset_with_runs):
+    timdex_dataset_with_runs.load(current_records=True, source="alma")
+    alma_records_df = timdex_dataset_with_runs.read_dataframe()
 
     # assert only alma records present and correct count
     assert alma_records_df.source.value_counts().to_dict() == {"alma": 100}
@@ -446,38 +462,38 @@ def test_dataset_source_current_records_deduped(dataset_with_runs):
 
 @pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
 def test_dataset_all_read_methods_get_deduplication(
-    dataset_with_runs,
+    timdex_dataset_with_runs,
 ):
-    dataset_with_runs.load(current_records=True, source="alma")
+    timdex_dataset_with_runs.load(current_records=True, source="alma")
 
-    full_df = dataset_with_runs.read_dataframe()
-    all_records = list(dataset_with_runs.read_dicts_iter())
-    transformed_records = list(dataset_with_runs.read_transformed_records_iter())
+    full_df = timdex_dataset_with_runs.read_dataframe()
+    all_records = list(timdex_dataset_with_runs.read_dicts_iter())
+    transformed_records = list(timdex_dataset_with_runs.read_transformed_records_iter())
 
     assert len(full_df) == len(all_records) == len(transformed_records)
 
 
 @pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
 def test_dataset_current_records_no_additional_filtering_accurate_records_yielded(
-    dataset_with_runs,
+    timdex_dataset_with_runs,
 ):
-    dataset_with_runs.load(current_records=True, source="alma")
-    df = dataset_with_runs.read_dataframe()
+    timdex_dataset_with_runs.load(current_records=True, source="alma")
+    df = timdex_dataset_with_runs.read_dataframe()
     assert df.action.value_counts().to_dict() == {"index": 99, "delete": 1}
 
 
 @pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
 def test_dataset_current_records_action_filtering_accurate_records_yielded(
-    dataset_with_runs,
+    timdex_dataset_with_runs,
 ):
-    dataset_with_runs.load(current_records=True, source="alma")
-    df = dataset_with_runs.read_dataframe(action="index")
+    timdex_dataset_with_runs.load(current_records=True, source="alma")
+    df = timdex_dataset_with_runs.read_dataframe(action="index")
     assert df.action.value_counts().to_dict() == {"index": 99}
 
 
 @pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
 def test_dataset_current_records_index_filtering_accurate_records_yielded(
-    dataset_with_runs,
+    timdex_dataset_with_runs,
 ):
     """This is a somewhat complex test, but demonstrates that only 'current' records
     are yielded when .load(current_records=True) is applied.
@@ -497,14 +513,14 @@ def test_dataset_current_records_index_filtering_accurate_records_yielded(
     "influenced" what records we would see as we continue backwards in time.
     """
     # with current_records=False, we get all 25 records from run-5
-    dataset_with_runs.load(current_records=False, source="alma")
-    df = dataset_with_runs.read_dataframe(run_id="run-5")
+    timdex_dataset_with_runs.load(current_records=False, source="alma")
+    df = timdex_dataset_with_runs.read_dataframe(run_id="run-5")
     assert len(df) == 25
 
     # with current_records=True, we only get 15 records from run-5
     # because newer run-6 influenced what records are current for older run-5
-    dataset_with_runs.load(current_records=True, source="alma")
-    df = dataset_with_runs.read_dataframe(run_id="run-5")
+    timdex_dataset_with_runs.load(current_records=True, source="alma")
+    df = timdex_dataset_with_runs.read_dataframe(run_id="run-5")
     assert len(df) == 15
     assert list(df.timdex_record_id) == [
         "alma:10",
@@ -527,36 +543,36 @@ def test_dataset_current_records_index_filtering_accurate_records_yielded(
 
 @pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
 def test_dataset_load_current_records_gets_correct_same_day_full_run(
-    dataset_with_same_day_runs,
+    timdex_dataset_same_day_runs,
 ):
     """Two full runs were performed on the same day, but 'run-2' was performed most
     recently.  current_records=True should discover the more recent of the two 'run-2',
     not 'run-1'."""
-    dataset_with_same_day_runs.load(current_records=True, run_type="full")
-    df = dataset_with_same_day_runs.read_dataframe()
+    timdex_dataset_same_day_runs.load(current_records=True, run_type="full")
+    df = timdex_dataset_same_day_runs.read_dataframe()
 
     assert list(df.run_id.unique()) == ["run-2"]
 
 
 @pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
 def test_dataset_load_current_records_gets_correct_same_day_daily_runs_ordering(
-    dataset_with_same_day_runs,
+    timdex_dataset_same_day_runs,
 ):
     """Two runs were performed on 2025-01-02, but the most recent records should be from
     run 'run-5' which are action='delete', not 'run-4' with action='index'."""
-    dataset_with_same_day_runs.load(current_records=True, run_type="daily")
-    first_record = next(dataset_with_same_day_runs.read_dicts_iter())
+    timdex_dataset_same_day_runs.load(current_records=True, run_type="daily")
+    first_record = next(timdex_dataset_same_day_runs.read_dicts_iter())
 
     assert first_record["run_id"] == "run-5"
     assert first_record["action"] == "delete"
 
 
-def test_dataset_records_data_structure_is_idempotent(dataset_with_runs):
-    assert os.path.exists(dataset_with_runs.data_records_root)
-    start_file_count = glob.glob(f"{dataset_with_runs.data_records_root}/**/*")
+def test_dataset_records_data_structure_is_idempotent(timdex_dataset_with_runs):
+    assert os.path.exists(timdex_dataset_with_runs.data_records_root)
+    start_file_count = glob.glob(f"{timdex_dataset_with_runs.data_records_root}/**/*")
 
-    dataset_with_runs.create_data_structure()
+    timdex_dataset_with_runs.create_data_structure()
 
-    assert os.path.exists(dataset_with_runs.data_records_root)
-    end_file_count = glob.glob(f"{dataset_with_runs.data_records_root}/**/*")
+    assert os.path.exists(timdex_dataset_with_runs.data_records_root)
+    end_file_count = glob.glob(f"{timdex_dataset_with_runs.data_records_root}/**/*")
     assert start_file_count == end_file_count

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -7,8 +7,8 @@ from duckdb import DuckDBPyConnection
 from timdex_dataset_api import TIMDEXDatasetMetadata
 
 
-def test_tdm_init_no_metadata_file_warning_success(caplog, dataset_with_runs_location):
-    TIMDEXDatasetMetadata(dataset_with_runs_location)
+def test_tdm_init_no_metadata_file_warning_success(caplog, timdex_dataset_with_runs):
+    TIMDEXDatasetMetadata(timdex_dataset_with_runs.location)
 
     assert "Static metadata database not found" in caplog.text
 
@@ -20,48 +20,48 @@ def test_tdm_local_dataset_structure_properties(tmp_path):
     assert tdm_local.location_scheme == "file"
 
 
-def test_tdm_s3_dataset_structure_properties(mocked_timdex_bucket):
+def test_tdm_s3_dataset_structure_properties(s3_bucket_mocked):
     s3_root = "s3://timdex/dataset"
     tdm_s3 = TIMDEXDatasetMetadata(s3_root)
     assert tdm_s3.location == s3_root
     assert tdm_s3.location_scheme == "s3"
 
 
-def test_tdm_create_metadata_database_file_success(caplog, timdex_dataset_metadata_empty):
+def test_tdm_create_metadata_database_file_success(caplog, timdex_metadata_empty):
     caplog.set_level("DEBUG")
-    timdex_dataset_metadata_empty.recreate_static_database_file()
+    timdex_metadata_empty.recreate_static_database_file()
 
 
-def test_tdm_init_metadata_file_found_success(timdex_dataset_metadata):
-    assert isinstance(timdex_dataset_metadata.conn, DuckDBPyConnection)
+def test_tdm_init_metadata_file_found_success(timdex_metadata):
+    assert isinstance(timdex_metadata.conn, DuckDBPyConnection)
 
 
-def test_tdm_connection_has_static_database_attached(timdex_dataset_metadata):
+def test_tdm_connection_has_static_database_attached(timdex_metadata):
     assert set(
-        timdex_dataset_metadata.conn.query("""show databases;""").to_df().database_name
+        timdex_metadata.conn.query("""show databases;""").to_df().database_name
     ) == {"memory", "static_db"}
 
 
-def test_tdm_connection_static_database_records_table_exists(timdex_dataset_metadata):
-    records_df = timdex_dataset_metadata.conn.query(
+def test_tdm_connection_static_database_records_table_exists(timdex_metadata):
+    records_df = timdex_metadata.conn.query(
         """select * from static_db.records;"""
     ).to_df()
     assert len(records_df) > 0
 
 
-def test_dataset_metadata_structure_is_idempotent(timdex_dataset_metadata):
-    assert os.path.exists(timdex_dataset_metadata.metadata_root)
-    start_file_count = glob.glob(f"{timdex_dataset_metadata.metadata_root}/**/*")
+def test_dataset_metadata_structure_is_idempotent(timdex_metadata):
+    assert os.path.exists(timdex_metadata.metadata_root)
+    start_file_count = glob.glob(f"{timdex_metadata.metadata_root}/**/*")
 
-    timdex_dataset_metadata.create_metadata_structure()
+    timdex_metadata.create_metadata_structure()
 
-    assert os.path.exists(timdex_dataset_metadata.metadata_root)
-    end_file_count = glob.glob(f"{timdex_dataset_metadata.metadata_root}/**/*")
+    assert os.path.exists(timdex_metadata.metadata_root)
+    end_file_count = glob.glob(f"{timdex_metadata.metadata_root}/**/*")
     assert start_file_count == end_file_count
 
 
-def test_tdm_views_created_on_init(timdex_dataset_metadata):
-    views = timdex_dataset_metadata.conn.query(
+def test_tdm_views_created_on_init(timdex_metadata):
+    views = timdex_metadata.conn.query(
         """select table_name from information_schema.tables where table_type = 'VIEW';"""
     ).to_df()
 
@@ -70,10 +70,8 @@ def test_tdm_views_created_on_init(timdex_dataset_metadata):
     assert expected_views <= actual_views
 
 
-def test_tdm_records_view_structure(timdex_dataset_metadata):
-    records_df = timdex_dataset_metadata.conn.query(
-        """select * from records limit 1;"""
-    ).to_df()
+def test_tdm_records_view_structure(timdex_metadata):
+    records_df = timdex_metadata.conn.query("""select * from records limit 1;""").to_df()
     expected_columns = {
         "timdex_record_id",
         "source",
@@ -88,8 +86,8 @@ def test_tdm_records_view_structure(timdex_dataset_metadata):
     assert set(records_df.columns) == expected_columns
 
 
-def test_tdm_current_records_view_structure(timdex_dataset_metadata):
-    current_records_df = timdex_dataset_metadata.conn.query(
+def test_tdm_current_records_view_structure(timdex_metadata):
+    current_records_df = timdex_metadata.conn.query(
         """select * from current_records limit 1;"""
     ).to_df()
     expected_columns = {
@@ -106,8 +104,8 @@ def test_tdm_current_records_view_structure(timdex_dataset_metadata):
     assert set(current_records_df.columns) == expected_columns
 
 
-def test_tdm_append_deltas_view_empty_structure(timdex_dataset_metadata):
-    append_deltas_df = timdex_dataset_metadata.conn.query(
+def test_tdm_append_deltas_view_empty_structure(timdex_metadata):
+    append_deltas_df = timdex_metadata.conn.query(
         """select * from append_deltas;"""
     ).to_df()
     expected_columns = {
@@ -125,48 +123,48 @@ def test_tdm_append_deltas_view_empty_structure(timdex_dataset_metadata):
     assert len(append_deltas_df) == 0
 
 
-def test_tdm_records_count_property(timdex_dataset_metadata):
-    assert timdex_dataset_metadata.records_count > 0
+def test_tdm_records_count_property(timdex_metadata):
+    assert timdex_metadata.records_count > 0
 
-    manual_count = timdex_dataset_metadata.conn.query(
+    manual_count = timdex_metadata.conn.query(
         """select count(*) from records;"""
     ).fetchone()[0]
-    assert timdex_dataset_metadata.records_count == manual_count
+    assert timdex_metadata.records_count == manual_count
 
 
-def test_tdm_current_records_count_property(timdex_dataset_metadata):
-    assert timdex_dataset_metadata.current_records_count > 0
+def test_tdm_current_records_count_property(timdex_metadata):
+    assert timdex_metadata.current_records_count > 0
 
-    manual_count = timdex_dataset_metadata.conn.query(
+    manual_count = timdex_metadata.conn.query(
         """select count(*) from current_records;"""
     ).fetchone()[0]
-    assert timdex_dataset_metadata.current_records_count == manual_count
+    assert timdex_metadata.current_records_count == manual_count
 
 
-def test_tdm_append_deltas_count_property_empty(timdex_dataset_metadata):
-    assert timdex_dataset_metadata.append_deltas_count == 0
+def test_tdm_append_deltas_count_property_empty(timdex_metadata):
+    assert timdex_metadata.append_deltas_count == 0
 
 
-def test_tdm_records_equals_static_without_deltas(timdex_dataset_metadata):
-    static_count = timdex_dataset_metadata.conn.query(
+def test_tdm_records_equals_static_without_deltas(timdex_metadata):
+    static_count = timdex_metadata.conn.query(
         """select count(*) from static_db.records;"""
     ).fetchone()[0]
-    records_count = timdex_dataset_metadata.conn.query(
+    records_count = timdex_metadata.conn.query(
         """select count(*) from records;"""
     ).fetchone()[0]
     assert static_count == records_count
 
 
-def test_tdm_current_records_filtering_logic(timdex_dataset_metadata):
-    current_count = timdex_dataset_metadata.current_records_count
-    total_count = timdex_dataset_metadata.records_count
+def test_tdm_current_records_filtering_logic(timdex_metadata):
+    current_count = timdex_metadata.current_records_count
+    total_count = timdex_metadata.records_count
 
     assert current_count <= total_count
     assert current_count > 0
 
 
-def test_tdm_views_with_append_deltas(timdex_dataset_metadata_with_deltas):
-    views = timdex_dataset_metadata_with_deltas.conn.query(
+def test_tdm_views_with_append_deltas(timdex_metadata_with_deltas):
+    views = timdex_metadata_with_deltas.conn.query(
         """select table_name from information_schema.tables where table_type = 'VIEW';"""
     ).to_df()
 
@@ -175,31 +173,31 @@ def test_tdm_views_with_append_deltas(timdex_dataset_metadata_with_deltas):
     assert expected_views.issubset(actual_views)
 
 
-def test_tdm_append_deltas_view_has_data(timdex_dataset_metadata_with_deltas):
-    append_deltas_count = timdex_dataset_metadata_with_deltas.append_deltas_count
+def test_tdm_append_deltas_view_has_data(timdex_metadata_with_deltas):
+    append_deltas_count = timdex_metadata_with_deltas.append_deltas_count
     assert append_deltas_count > 0
 
 
-def test_tdm_records_includes_deltas(timdex_dataset_metadata_with_deltas):
-    static_count = timdex_dataset_metadata_with_deltas.conn.query(
+def test_tdm_records_includes_deltas(timdex_metadata_with_deltas):
+    static_count = timdex_metadata_with_deltas.conn.query(
         """select count(*) from static_db.records;"""
     ).fetchone()[0]
-    deltas_count = timdex_dataset_metadata_with_deltas.append_deltas_count
-    records_count = timdex_dataset_metadata_with_deltas.records_count
+    deltas_count = timdex_metadata_with_deltas.append_deltas_count
+    records_count = timdex_metadata_with_deltas.records_count
 
     assert records_count == static_count + deltas_count
     assert records_count > static_count
 
 
-def test_tdm_current_records_with_deltas_logic(timdex_dataset_metadata_with_deltas):
-    current_count = timdex_dataset_metadata_with_deltas.current_records_count
-    total_count = timdex_dataset_metadata_with_deltas.records_count
+def test_tdm_current_records_with_deltas_logic(timdex_metadata_with_deltas):
+    current_count = timdex_metadata_with_deltas.current_records_count
+    total_count = timdex_metadata_with_deltas.records_count
 
     assert current_count <= total_count
     assert current_count > 0
 
     # verify current records view returns unique timdex_record_id values
-    current_records_df = timdex_dataset_metadata_with_deltas.conn.query(
+    current_records_df = timdex_metadata_with_deltas.conn.query(
         """select timdex_record_id from current_records;"""
     ).to_df()
 
@@ -207,9 +205,9 @@ def test_tdm_current_records_with_deltas_logic(timdex_dataset_metadata_with_delt
     assert unique_count == current_count
 
 
-def test_tdm_current_records_most_recent_version(timdex_dataset_metadata_with_deltas):
+def test_tdm_current_records_most_recent_version(timdex_metadata_with_deltas):
     # check that for records with multiple versions, only the most recent is returned
-    multi_version_records = timdex_dataset_metadata_with_deltas.conn.query(
+    multi_version_records = timdex_metadata_with_deltas.conn.query(
         """
         select timdex_record_id, count(*) as version_count
         from records
@@ -223,7 +221,7 @@ def test_tdm_current_records_most_recent_version(timdex_dataset_metadata_with_de
         record_id = multi_version_records.iloc[0]["timdex_record_id"]
 
         # get most recent timestamp for this record
-        most_recent = timdex_dataset_metadata_with_deltas.conn.query(
+        most_recent = timdex_metadata_with_deltas.conn.query(
             f"""
             select run_timestamp, run_id
             from records
@@ -234,7 +232,7 @@ def test_tdm_current_records_most_recent_version(timdex_dataset_metadata_with_de
         ).to_df()
 
         # verify current_records contains this version
-        current_version = timdex_dataset_metadata_with_deltas.conn.query(
+        current_version = timdex_metadata_with_deltas.conn.query(
             f"""
             select run_timestamp, run_id
             from current_records

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -9,33 +9,33 @@ from timdex_dataset_api.dataset import TIMDEX_DATASET_SCHEMA
 DATASET_COLUMNS_SET = set(TIMDEX_DATASET_SCHEMA.names)
 
 
-def test_read_batches_yields_pyarrow_record_batches(fixed_local_dataset):
-    batches = fixed_local_dataset.read_batches_iter()
+def test_read_batches_yields_pyarrow_record_batches(timdex_dataset_multi_source):
+    batches = timdex_dataset_multi_source.read_batches_iter()
     batch = next(batches)
     assert isinstance(batch, pa.RecordBatch)
 
 
-def test_read_batches_all_columns_by_default(fixed_local_dataset):
-    batches = fixed_local_dataset.read_batches_iter()
+def test_read_batches_all_columns_by_default(timdex_dataset_multi_source):
+    batches = timdex_dataset_multi_source.read_batches_iter()
     batch = next(batches)
     assert set(batch.column_names) == DATASET_COLUMNS_SET
 
 
-def test_read_batches_filter_columns(fixed_local_dataset):
+def test_read_batches_filter_columns(timdex_dataset_multi_source):
     columns_subset = ["source", "transformed_record"]
-    batches = fixed_local_dataset.read_batches_iter(columns=columns_subset)
+    batches = timdex_dataset_multi_source.read_batches_iter(columns=columns_subset)
     batch = next(batches)
     assert set(batch.column_names) == set(columns_subset)
 
 
-def test_read_batches_no_filters_gets_full_dataset(fixed_local_dataset):
-    batches = fixed_local_dataset.read_batches_iter()
+def test_read_batches_no_filters_gets_full_dataset(timdex_dataset_multi_source):
+    batches = timdex_dataset_multi_source.read_batches_iter()
     table = pa.Table.from_batches(batches)
-    assert len(table) == fixed_local_dataset.row_count
+    assert len(table) == timdex_dataset_multi_source.row_count
 
 
-def test_read_batches_with_filters_gets_subset_of_dataset(fixed_local_dataset):
-    batches = fixed_local_dataset.read_batches_iter(
+def test_read_batches_with_filters_gets_subset_of_dataset(timdex_dataset_multi_source):
+    batches = timdex_dataset_multi_source.read_batches_iter(
         source="libguides",
         run_date="2024-12-01",
         run_type="daily",
@@ -44,45 +44,49 @@ def test_read_batches_with_filters_gets_subset_of_dataset(fixed_local_dataset):
 
     table = pa.Table.from_batches(batches)
     assert len(table) == 1_000
-    assert len(table) < fixed_local_dataset.row_count
+    assert len(table) < timdex_dataset_multi_source.row_count
 
     # assert loaded dataset is unchanged by filtering for a read method
-    assert fixed_local_dataset.row_count == 5_000
+    assert timdex_dataset_multi_source.row_count == 5_000
 
 
-def test_read_dataframe_batches_yields_dataframes(fixed_local_dataset):
-    df_iter = fixed_local_dataset.read_dataframes_iter()
+def test_read_dataframe_batches_yields_dataframes(timdex_dataset_multi_source):
+    df_iter = timdex_dataset_multi_source.read_dataframes_iter()
     df_batch = next(df_iter)
     assert isinstance(df_batch, pd.DataFrame)
     assert len(df_batch) == 1_000
 
 
-def test_read_dataframe_reads_all_dataset_rows_after_filtering(fixed_local_dataset):
-    df = fixed_local_dataset.read_dataframe()
+def test_read_dataframe_reads_all_dataset_rows_after_filtering(
+    timdex_dataset_multi_source,
+):
+    df = timdex_dataset_multi_source.read_dataframe()
     assert isinstance(df, pd.DataFrame)
-    assert len(df) == fixed_local_dataset.row_count
+    assert len(df) == timdex_dataset_multi_source.row_count
 
 
-def test_read_dicts_yields_dictionary_for_each_dataset_record(fixed_local_dataset):
-    records = fixed_local_dataset.read_dicts_iter()
+def test_read_dicts_yields_dictionary_for_each_dataset_record(
+    timdex_dataset_multi_source,
+):
+    records = timdex_dataset_multi_source.read_dicts_iter()
     record = next(records)
     assert isinstance(record, dict)
     assert set(record.keys()) == DATASET_COLUMNS_SET
 
 
-def test_read_batches_filter_to_none_returns_empty_list(fixed_local_dataset):
-    batches = fixed_local_dataset.read_batches_iter(source="not-gonna-find-me")
+def test_read_batches_filter_to_none_returns_empty_list(timdex_dataset_multi_source):
+    batches = timdex_dataset_multi_source.read_batches_iter(source="not-gonna-find-me")
     assert list(batches) == []
 
 
-def test_read_dicts_filter_to_none_stopiteration_immediately(fixed_local_dataset):
-    batches = fixed_local_dataset.read_dicts_iter(source="not-gonna-find-me")
+def test_read_dicts_filter_to_none_stopiteration_immediately(timdex_dataset_multi_source):
+    batches = timdex_dataset_multi_source.read_dicts_iter(source="not-gonna-find-me")
     with pytest.raises(StopIteration):
         next(batches)
 
 
-def test_read_transformed_records_yields_parsed_dictionary(fixed_local_dataset):
-    batches = fixed_local_dataset.read_transformed_records_iter()
+def test_read_transformed_records_yields_parsed_dictionary(timdex_dataset_multi_source):
+    batches = timdex_dataset_multi_source.read_transformed_records_iter()
     transformed_record = next(batches)
     assert isinstance(transformed_record, dict)
     assert transformed_record == {"title": ["Hello World."]}

--- a/tests/test_s3client.py
+++ b/tests/test_s3client.py
@@ -42,7 +42,7 @@ def test_split_s3_uri_invalid():
         client._split_s3_uri("timdex/path/to/file.txt")
 
 
-def test_upload_download_file(mocked_timdex_bucket, tmp_path):
+def test_upload_download_file(s3_bucket_mocked, tmp_path):
     """Test upload_file and download_file methods."""
     client = S3Client()
 
@@ -62,7 +62,7 @@ def test_upload_download_file(mocked_timdex_bucket, tmp_path):
     assert download_path.read_text() == "test content"
 
 
-def test_delete_file(mocked_timdex_bucket, tmp_path):
+def test_delete_file(s3_bucket_mocked, tmp_path):
     """Test delete_file method."""
     client = S3Client()
 
@@ -76,12 +76,12 @@ def test_delete_file(mocked_timdex_bucket, tmp_path):
     client.delete_file(s3_uri)
 
     # Verify the file is deleted
-    bucket = mocked_timdex_bucket.Bucket("timdex")
+    bucket = s3_bucket_mocked.Bucket("timdex")
     objects = list(bucket.objects.all())
     assert len(objects) == 0
 
 
-def test_delete_folder(mocked_timdex_bucket, tmp_path):
+def test_delete_folder(s3_bucket_mocked, tmp_path):
     """Test delete_folder method."""
     client = S3Client()
 
@@ -104,7 +104,7 @@ def test_delete_folder(mocked_timdex_bucket, tmp_path):
     assert len(deleted_keys) == 3
     assert all(key.startswith("folder/") for key in deleted_keys)
 
-    bucket = mocked_timdex_bucket.Bucket("timdex")
+    bucket = s3_bucket_mocked.Bucket("timdex")
     objects = list(bucket.objects.all())
     assert len(objects) == 1
     assert objects[0].key == "other.txt"

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -16,49 +16,53 @@ from timdex_dataset_api.dataset import (
 from timdex_dataset_api.metadata import ORDERED_METADATA_COLUMN_NAMES
 
 
-def test_dataset_write_records_to_new_local_dataset(
-    new_local_dataset, sample_records_iter
+def test_dataset_write_records_to_timdex_dataset_empty(
+    timdex_dataset_empty, sample_records_generator
 ):
-    written_files = new_local_dataset.write(sample_records_iter(10_000))
-    new_local_dataset.load()
+    written_files = timdex_dataset_empty.write(sample_records_generator(10_000))
+    timdex_dataset_empty.load()
 
     assert len(written_files) == 1
-    assert os.path.exists(new_local_dataset.location)
-    assert new_local_dataset.row_count == 10_000
+    assert os.path.exists(timdex_dataset_empty.location)
+    assert timdex_dataset_empty.row_count == 10_000
 
 
-def test_dataset_write_default_max_rows_per_file(new_local_dataset, sample_records_iter):
+def test_dataset_write_default_max_rows_per_file(
+    timdex_dataset_empty, sample_records_generator
+):
     """Default is 100k rows per file, therefore writing 200,033 records should result in
     3 files (x2 @ 100k rows, x1 @ 33 rows)."""
-    default_max_rows_per_file = new_local_dataset.config.max_rows_per_file
+    default_max_rows_per_file = timdex_dataset_empty.config.max_rows_per_file
     total_records = 200_033
 
-    new_local_dataset.write(sample_records_iter(total_records))
-    new_local_dataset.load()
+    timdex_dataset_empty.write(sample_records_generator(total_records))
+    timdex_dataset_empty.load()
 
-    assert new_local_dataset.row_count == total_records
-    assert len(new_local_dataset.dataset.files) == math.ceil(
+    assert timdex_dataset_empty.row_count == total_records
+    assert len(timdex_dataset_empty.dataset.files) == math.ceil(
         total_records / default_max_rows_per_file
     )
 
 
 def test_dataset_write_record_batches_uses_batch_size(
-    new_local_dataset, sample_records_iter
+    timdex_dataset_empty, sample_records_generator
 ):
     total_records = 101
-    new_local_dataset.config.write_batch_size = 50
+    timdex_dataset_empty.config.write_batch_size = 50
     batches = list(
-        new_local_dataset.create_record_batches(sample_records_iter(total_records))
+        timdex_dataset_empty.create_record_batches(
+            sample_records_generator(total_records)
+        )
     )
     assert len(batches) == math.ceil(
-        total_records / new_local_dataset.config.write_batch_size
+        total_records / timdex_dataset_empty.config.write_batch_size
     )
 
 
 @pytest.mark.skip(
     reason="Test unneeded soon when list[str] not supported for dataset location."
 )
-def test_dataset_write_to_multiple_locations_raise_error(sample_records_iter):
+def test_dataset_write_to_multiple_locations_raise_error(sample_records_generator):
     timdex_dataset = TIMDEXDataset(
         location=["/path/to/records-1.parquet", "/path/to/records-2.parquet"]
     )
@@ -66,16 +70,18 @@ def test_dataset_write_to_multiple_locations_raise_error(sample_records_iter):
         TypeError,
         match="Dataset location must be the root of a single dataset for writing",
     ):
-        timdex_dataset.write(sample_records_iter(10))
+        timdex_dataset.write(sample_records_generator(10))
 
 
-def test_dataset_write_schema_applied_to_dataset(new_local_dataset, sample_records_iter):
-    new_local_dataset.write(sample_records_iter(10))
+def test_dataset_write_schema_applied_to_dataset(
+    timdex_dataset_empty, sample_records_generator
+):
+    timdex_dataset_empty.write(sample_records_generator(10))
 
     # manually load dataset to confirm schema without TIMDEXDataset projecting schema
     # during load
     dataset = ds.dataset(
-        new_local_dataset.location,
+        timdex_dataset_empty.location,
         format="parquet",
         partitioning="hive",
     )
@@ -84,52 +90,52 @@ def test_dataset_write_schema_applied_to_dataset(new_local_dataset, sample_recor
 
 
 def test_dataset_write_partition_for_single_source(
-    new_local_dataset, sample_records_iter
+    timdex_dataset_empty, sample_records_generator
 ):
-    written_files = new_local_dataset.write(sample_records_iter(10))
+    written_files = timdex_dataset_empty.write(sample_records_generator(10))
     assert len(written_files) == 1
-    assert os.path.exists(new_local_dataset.location)
+    assert os.path.exists(timdex_dataset_empty.location)
     assert "year=2024/month=12/day=01" in written_files[0].path
 
 
 def test_dataset_write_partition_for_multiple_sources(
-    new_local_dataset, sample_records_iter
+    timdex_dataset_empty, sample_records_generator
 ):
     # perform write for source="alma" and run_date="2024-12-01"
-    written_files_source_a = new_local_dataset.write(sample_records_iter(10))
-    new_local_dataset.load()
+    written_files_source_a = timdex_dataset_empty.write(sample_records_generator(10))
+    timdex_dataset_empty.load()
 
     assert os.path.exists(written_files_source_a[0].path)
-    assert new_local_dataset.row_count == 10
+    assert timdex_dataset_empty.row_count == 10
 
     # perform write for source="libguides" and run_date="2024-12-01"
-    written_files_source_b = new_local_dataset.write(
+    written_files_source_b = timdex_dataset_empty.write(
         generate_sample_records(num_records=7, source="libguides")
     )
-    new_local_dataset.load()
+    timdex_dataset_empty.load()
 
     assert os.path.exists(written_files_source_b[0].path)
     assert os.path.exists(written_files_source_a[0].path)
-    assert new_local_dataset.row_count == 17
+    assert timdex_dataset_empty.row_count == 17
 
 
 def test_dataset_write_partition_ignore_existing_data(
-    new_local_dataset, sample_records_iter
+    timdex_dataset_empty, sample_records_generator
 ):
     # perform two (2) writes for source="alma" and run_date="2024-12-01"
-    written_files_source_a0 = new_local_dataset.write(sample_records_iter(10))
-    written_files_source_a1 = new_local_dataset.write(sample_records_iter(10))
-    new_local_dataset.load()
+    written_files_source_a0 = timdex_dataset_empty.write(sample_records_generator(10))
+    written_files_source_a1 = timdex_dataset_empty.write(sample_records_generator(10))
+    timdex_dataset_empty.load()
 
     # assert that both files exist and no overwriting occurs
     assert os.path.exists(written_files_source_a0[0].path)
     assert os.path.exists(written_files_source_a1[0].path)
-    assert new_local_dataset.row_count == 20
+    assert timdex_dataset_empty.row_count == 20
 
 
 @patch("timdex_dataset_api.dataset.uuid.uuid4")
 def test_dataset_write_partition_overwrite_files_with_same_name(
-    mock_uuid, new_local_dataset, sample_records_iter
+    mock_uuid, timdex_dataset_empty, sample_records_generator
 ):
     """This test is to demonstrate existing_data_behavior="overwrite_or_ignore".
 
@@ -140,45 +146,47 @@ def test_dataset_write_partition_overwrite_files_with_same_name(
     mock_uuid.return_value = "abc"
 
     # perform two (2) writes for source="alma" and run_date="2024-12-01"
-    _ = new_local_dataset.write(sample_records_iter(10))
-    written_files_source_a1 = new_local_dataset.write(sample_records_iter(7))
-    new_local_dataset.load()
+    _ = timdex_dataset_empty.write(sample_records_generator(10))
+    written_files_source_a1 = timdex_dataset_empty.write(sample_records_generator(7))
+    timdex_dataset_empty.load()
 
     # assert that only the second file exists and overwriting occurs
     assert os.path.exists(written_files_source_a1[0].path)
-    assert new_local_dataset.row_count == 7
+    assert timdex_dataset_empty.row_count == 7
 
 
 def test_dataset_write_single_append_delta_success(
-    new_local_dataset, sample_records_iter
+    timdex_dataset_empty, sample_records_generator
 ):
-    written_files = new_local_dataset.write(sample_records_iter(1_000))
-    append_deltas = os.listdir(new_local_dataset.metadata.append_deltas_path)
+    written_files = timdex_dataset_empty.write(sample_records_generator(1_000))
+    append_deltas = os.listdir(timdex_dataset_empty.metadata.append_deltas_path)
 
     assert len(append_deltas) == len(written_files)
 
 
 def test_dataset_write_multiple_append_deltas_success(
-    new_local_dataset, sample_records_iter
+    timdex_dataset_empty, sample_records_generator
 ):
     """Expecting 10 ETL parquet files written, and so 10 append deltas as well."""
-    new_local_dataset.config.max_rows_per_file = 100
-    new_local_dataset.config.max_rows_per_group = 100
+    timdex_dataset_empty.config.max_rows_per_file = 100
+    timdex_dataset_empty.config.max_rows_per_group = 100
 
-    written_files = new_local_dataset.write(sample_records_iter(1_000))
-    append_deltas = os.listdir(new_local_dataset.metadata.append_deltas_path)
+    written_files = timdex_dataset_empty.write(sample_records_generator(1_000))
+    append_deltas = os.listdir(timdex_dataset_empty.metadata.append_deltas_path)
 
     assert len(written_files) == 10
     assert len(append_deltas) == len(written_files)
 
 
 def test_dataset_write_append_delta_expected_metadata_columns(
-    new_local_dataset, sample_records_iter
+    timdex_dataset_empty, sample_records_generator
 ):
-    new_local_dataset.write(sample_records_iter(1_000))
-    append_delta_filepath = os.listdir(new_local_dataset.metadata.append_deltas_path)[0]
+    timdex_dataset_empty.write(sample_records_generator(1_000))
+    append_delta_filepath = os.listdir(timdex_dataset_empty.metadata.append_deltas_path)[
+        0
+    ]
 
     append_delta = pq.ParquetFile(
-        new_local_dataset.metadata.append_deltas_path / Path(append_delta_filepath)
+        timdex_dataset_empty.metadata.append_deltas_path / Path(append_delta_filepath)
     )
     assert append_delta.schema.names == ORDERED_METADATA_COLUMN_NAMES

--- a/timdex_dataset_api/dataset.py
+++ b/timdex_dataset_api/dataset.py
@@ -431,6 +431,7 @@ class TIMDEXDataset:
         if write_append_deltas:
             for written_file in written_files:
                 self.metadata.write_append_delta_duckdb(written_file.path)  # type: ignore[attr-defined]
+            self.metadata.refresh()
 
         self.log_write_statistics(start_time, written_files)
 


### PR DESCRIPTION
### Purpose and background context

This PR takes the work from TIMX-530 (create static metadata database file) and TIMX-527 (writing append deltas) and now provides dynamic database views that project over these data sources.

The following sketch attempts to show all the primary components at this point:

<img width="3873" height="1420" alt="timx_526_model" src="https://github.com/user-attachments/assets/6ed9ed7d-48f7-4b01-b0e5-1aaf5bd42c6d" />

- a single DuckDB context (connection) can be "attached" to multiple databases
  - we attach remotely in a readonly fashion to the static metadata file in S3
  - the other in-memory database is provided by default on connect, and is the primary database used
- the "TIMDEX Dataset" in the middle shows the data as it sits in S3
- the "DuckDB Context" on the right shows what the TDA library creates
  - this existed prior to this PR, but had minimal tables + views
  - this PR more fully realizes this DuckDB context
  - this "context" is purely in memory, with no data transferred until queries are performed, each time `TIMDEXDatasetMetadata` is initialized
  - only the `records` and `current_records` are designed to be used directly, the rest are building blocks

**Note**: the relatively high line count change is mostly part of [this commit which refactors the test fixtures](https://github.com/MITLibraries/timdex-dataset-api/pull/159/commits/05383bce6287386a90355ff60d3fddad88698a1c) which is 99% just moving and renaming.

#### Next steps:

- Fully rework `TIMDEXDataset.load()` and dataset "location", [TIMX-533](https://mitlibraries.atlassian.net/browse/TIMX-533)
- Rework read methods to use SQL + metadata, [TIMX-529](https://mitlibraries.atlassian.net/browse/TIMX-529)
- Merge append deltas into static DB, [TIMX-528](https://mitlibraries.atlassian.net/browse/TIMX-528)

### How can a reviewer manually see the effects of these changes?

1- Set AWS Dev `TimdexManagers` credentials

2- Set env vars:
```shell
TDA_LOG_LEVEL=DEBUG
WARNING_ONLY_LOGGERS=asyncio,botocore,urllib3,s3transfer,boto3,MARKDOWN
TIMDEX_DATASET_LOCATION=s3://timdex-extract-dev-222053980223/dataset_scratch
```

3- Start Ipython shell with `pipenv run ipython` and do some setup:
```python
import os

from timdex_dataset_api import TIMDEXDataset
from timdex_dataset_api.config import configure_dev_logger
from tests.utils import generate_sample_records

configure_dev_logger()

td = TIMDEXDataset(os.environ["TIMDEX_DATASET_LOCATION"])
```

4- Fully recreate dataset metadata for a clean slate:
```python
td.metadata.recreate_static_database_file()
```

5- Simulate an ETL write while will write some append deltas:
```
td.write(
    generate_sample_records(
        num_records=1000,
        source="gismit",
        run_date="2025-09-01",
        run_type="full",
    )
)
td.write(
    generate_sample_records(
        num_records=1,
        source="gismit",
        run_date="2025-09-02",
        run_type="daily",
        action="delete",
    )
)
```

After both `TIMDEXDataset.write()` methods, the metadata context has been updated.  This allows immediate metadata querying based on the new append deltas.

5- Perform some queries that demonstrate append deltas as present and used:
```python
# show tables/views
td.metadata.conn.query("""show tables;""")
"""
Out[4]: 
┌─────────────────┐
│      name       │
│     varchar     │
├─────────────────┤
│ append_deltas   │
│ current_records │
│ records         │
└─────────────────┘
"""

td.metadata.conn.query("""select count(*) from append_deltas;""")
"""
Out[5]: 
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│         1001 │
└──────────────┘
"""

# count distinct filenames in append deltas, expecting two from the two ETL writes
 td.metadata.conn.query("""select distinct filename from append_deltas;""")
"""
Out[6]: 
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                  filename                                                                  │
│                                                                  varchar                                                                   │
├────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ s3://timdex-extract-dev-222053980223/dataset_scratch/data/records/year=2025/month=09/day=02/3023210d-d3d3-4a06-9bd4-26bac33a7d3d-0.parquet │
│ s3://timdex-extract-dev-222053980223/dataset_scratch/data/records/year=2025/month=09/day=01/49652d90-1616-47da-bfd3-a355e0d43109-0.parquet │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
"""

# select metadata records that will pull from append deltas, but using the records table which is
# a union of static + append delta data
td.metadata.conn.query("""select count(*) from records where run_date > '2025-08-07';""")
"""
Out[7]: 
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│         1001 │
└──────────────┘
"""
```

The last query is particularly neat.  This is demonstrating the use of pure SQL to identify TIMDEX rows (the simulated runs were in the future), and it's pulling from data we haven't yet merged into the static metadata database file.

The work if a future PR, [TIMX-529](https://mitlibraries.atlassian.net/browse/TIMX-529), will be to allow retrieving full _records_ (e.g. source and transformed data) using similar SQL.   

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-526

[TIMX-533]: https://mitlibraries.atlassian.net/browse/TIMX-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ