### PR TITLE
TIMX 533 - Load pyarrow dataset on TIMDEXDataset init

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,6 @@ timdex_dataset = TIMDEXDataset("s3://my-bucket/path/to/dataset")
 
 # or, local dataset (e.g. testing or development)
 timdex_dataset = TIMDEXDataset("/path/to/dataset")
-
-# load the dataset, which discovers all parquet files
-timdex_dataset.load()
-
-# or, load the dataset but ensure that only current records are ever yielded
-timdex_dataset.load(current_records=True)
 ```
 
 All read methods for `TIMDEXDataset` allow for the same group of filters which are defined in `timdex_dataset_api.dataset.DatasetFilters`.  Examples are shown below.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ line-length = 90
 [tool.mypy]
 disallow_untyped_calls = true
 disallow_untyped_defs = true
-exclude = ["tests/", "output/"]
+exclude = ["tests/", "output/", "migrations/"]
 
 [[tool.mypy.overrides]]
 module = []
@@ -95,6 +95,8 @@ ignore = [
     "PLR0915",
     "S321",
     "S608",
+    "TD002",
+    "TD003",
     "TRY003"
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,6 @@ def timdex_dataset(tmp_path, timdex_dataset_config) -> TIMDEXDataset:
         ),
         write_append_deltas=False,
     )
-    dataset.load()
     return dataset
 
 
@@ -110,8 +109,6 @@ def timdex_dataset_multi_source(tmp_path) -> TIMDEXDataset:
             ),
             write_append_deltas=False,
         )
-
-    dataset.load()
     return dataset
 
 
@@ -165,8 +162,6 @@ def timdex_dataset_with_runs(tmp_path, timdex_dataset_config_small) -> TIMDEXDat
             ),
             write_append_deltas=False,
         )
-
-    dataset.load()
     return dataset
 
 
@@ -202,8 +197,6 @@ def timdex_dataset_same_day_runs(tmp_path) -> TIMDEXDataset:
             ),
             write_append_deltas=False,
         )
-
-    dataset.load()
     return dataset
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -11,44 +11,14 @@ import pytest
 from pyarrow import fs
 
 from timdex_dataset_api.dataset import (
-    DatasetNotLoadedError,
     TIMDEXDataset,
     TIMDEXDatasetConfig,
 )
 
 
-@pytest.mark.parametrize(
-    ("location_param", "expected_file_system", "expected_source_param"),
-    [
-        (
-            "path/to/dataset",
-            fs.LocalFileSystem,
-            "path/to/dataset/data/records",
-        ),
-        (
-            "s3://timdex/path/to/dataset",
-            fs.S3FileSystem,
-            "timdex/path/to/dataset/data/records",
-        ),
-    ],
-)
-def test_dataset_init_success(
-    location_param,
-    expected_file_system,
-    expected_source_param,
-    s3_bucket_mocked,
-    tmp_path,
-):
-    location = location_param
-    expected_source = expected_source_param
-
-    if not location.startswith("s3://"):
-        location = str(tmp_path / location)
-        expected_source = str(tmp_path / expected_source)
-
-    timdex_dataset = TIMDEXDataset(location=location)
-    assert isinstance(timdex_dataset.filesystem, expected_file_system)
-    assert timdex_dataset.paths == expected_source
+def test_dataset_init_success(tmp_path):
+    timdex_dataset = TIMDEXDataset(str(tmp_path / "path/to/dataset"))
+    assert isinstance(timdex_dataset.dataset.filesystem, fs.LocalFileSystem)
 
 
 def test_dataset_init_env_vars_set_config(monkeypatch, tmp_path):
@@ -73,6 +43,65 @@ def test_dataset_init_custom_config_object(monkeypatch, tmp_path):
 
 @patch("timdex_dataset_api.dataset.fs.LocalFileSystem")
 @patch("timdex_dataset_api.dataset.ds.dataset")
+def test_load_pyarrow_dataset_default_uses_data_records_root(
+    mock_pyarrow_ds, mock_local_fs, tmp_path
+):
+    """Ensure load_pyarrow_dataset() without args calls pyarrow.dataset with the
+    dataset's data_records_root path as the source and the proper filesystem."""
+    mock_local_fs.return_value = MagicMock()
+    mock_pyarrow_ds.return_value = MagicMock()
+
+    location = str(Path(tmp_path) / "local/path/to/default_dataset")
+
+    timdex_dataset = TIMDEXDataset(location=location)
+    # call the explicit loader to exercise the code path
+    dataset_obj = timdex_dataset.load_pyarrow_dataset()
+
+    mock_pyarrow_ds.assert_called_with(
+        f"{location}/data/records",
+        schema=timdex_dataset.schema,
+        format="parquet",
+        partitioning="hive",
+        filesystem=mock_local_fs.return_value,
+    )
+    assert dataset_obj == mock_pyarrow_ds.return_value
+    assert timdex_dataset.dataset == mock_pyarrow_ds.return_value
+
+
+@patch("timdex_dataset_api.dataset.fs.LocalFileSystem")
+@patch("timdex_dataset_api.dataset.ds.dataset")
+def test_load_pyarrow_dataset_with_parquet_files_list(
+    mock_pyarrow_ds, mock_local_fs, tmp_path
+):
+    """Ensure load_pyarrow_dataset(parquet_files=...) passes the explicit list
+    of parquet files as the source to pyarrow.dataset."""
+    mock_local_fs.return_value = MagicMock()
+    mock_pyarrow_ds.return_value = MagicMock()
+
+    location = str(Path(tmp_path) / "local/path/to/dataset_with_files")
+
+    timdex_dataset = TIMDEXDataset(location=location)
+
+    parquet_files = [
+        f"{timdex_dataset.data_records_root}/source=alma/run_date=2024-12-01/part-0.parquet",
+        f"{timdex_dataset.data_records_root}/source=alma/run_date=2024-12-01/part-1.parquet",
+    ]
+
+    dataset_obj = timdex_dataset.load_pyarrow_dataset(parquet_files=parquet_files)
+
+    mock_pyarrow_ds.assert_called_with(
+        parquet_files,
+        schema=timdex_dataset.schema,
+        format="parquet",
+        partitioning="hive",
+        filesystem=mock_local_fs.return_value,
+    )
+    assert dataset_obj == mock_pyarrow_ds.return_value
+    assert timdex_dataset.dataset == mock_pyarrow_ds.return_value
+
+
+@patch("timdex_dataset_api.dataset.fs.LocalFileSystem")
+@patch("timdex_dataset_api.dataset.ds.dataset")
 def test_dataset_load_local_sets_filesystem_and_dataset_success(
     mock_pyarrow_ds, mock_local_fs, tmp_path
 ):
@@ -82,7 +111,6 @@ def test_dataset_load_local_sets_filesystem_and_dataset_success(
     location = str(Path(tmp_path) / "local/path/to/dataset")
 
     timdex_dataset = TIMDEXDataset(location=location)
-    result = timdex_dataset.load()
 
     mock_pyarrow_ds.assert_called_once_with(
         f"{location}/data/records",
@@ -93,7 +121,6 @@ def test_dataset_load_local_sets_filesystem_and_dataset_success(
     )
 
     assert timdex_dataset.dataset == mock_pyarrow_ds.return_value
-    assert result is None
 
 
 @patch("timdex_dataset_api.dataset.TIMDEXDataset.get_s3_filesystem")
@@ -105,7 +132,6 @@ def test_dataset_load_s3_sets_filesystem_and_dataset_success(
     mock_pyarrow_ds.return_value = MagicMock()
 
     timdex_dataset = TIMDEXDataset(location="s3://timdex/path/to/dataset")
-    result = timdex_dataset.load()
 
     mock_pyarrow_ds.assert_called_with(
         "timdex/path/to/dataset/data/records",
@@ -115,88 +141,11 @@ def test_dataset_load_s3_sets_filesystem_and_dataset_success(
         filesystem=mock_get_s3_fs.return_value,
     )
     assert timdex_dataset.dataset == mock_pyarrow_ds.return_value
-    assert result is None
-
-
-def test_dataset_load_without_filters_success(timdex_dataset_multi_source):
-    timdex_dataset_multi_source.load()
-
-    assert os.path.exists(timdex_dataset_multi_source.location)
-    assert timdex_dataset_multi_source.row_count == 5_000
-
-
-def test_dataset_load_with_run_date_str_filters_success(timdex_dataset_multi_source):
-    timdex_dataset_multi_source.load(run_date="2024-12-01")
-
-    assert os.path.exists(timdex_dataset_multi_source.location)
-    assert timdex_dataset_multi_source.row_count == 5_000
-
-
-def test_dataset_load_with_run_date_obj_filters_success(timdex_dataset_multi_source):
-    timdex_dataset_multi_source.load(run_date=date(2024, 12, 1))
-
-    assert os.path.exists(timdex_dataset_multi_source.location)
-    assert timdex_dataset_multi_source.row_count == 5_000
-
-
-def test_dataset_load_with_ymd_filters_success(timdex_dataset_multi_source):
-    timdex_dataset_multi_source.load(year="2024", month="12", day="01")
-
-    assert os.path.exists(timdex_dataset_multi_source.location)
-    assert timdex_dataset_multi_source.row_count == 5_000
-
-
-def test_dataset_load_with_single_nonpartition_filters_success(
-    timdex_dataset_multi_source,
-):
-    timdex_dataset_multi_source.load(timdex_record_id="alma:0")
-
-    assert timdex_dataset_multi_source.row_count == 1
-
-
-def test_dataset_load_with_multi_nonpartition_filters_success(
-    timdex_dataset_multi_source,
-):
-    timdex_dataset_multi_source.load(
-        timdex_record_id="alma:0",
-        source="alma",
-        run_type="daily",
-        run_id="abc123",
-        action="index",
-    )
-
-    assert timdex_dataset_multi_source.row_count == 1
-
-
-@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
-def test_dataset_load_current_records_all_sources_success(
-    timdex_timdex_dataset_with_runs,
-):
-    timdex_dataset = TIMDEXDataset(timdex_timdex_dataset_with_runs.location)
-
-    # 16 total parquet files, with current_records=False we get them all
-    timdex_dataset.load(current_records=False)
-    assert len(timdex_dataset.dataset.files) == 16
-
-    # 16 total parquet files, with current_records=True we only get 12 for current runs
-    timdex_dataset.load(current_records=True)
-    assert len(timdex_dataset.dataset.files) == 12
-
-
-@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
-def test_dataset_load_current_records_one_source_success(timdex_timdex_dataset_with_runs):
-    timdex_dataset = TIMDEXDataset(timdex_timdex_dataset_with_runs.location)
-    timdex_dataset.load(current_records=True, source="alma")
-
-    # 7 total parquet files for source, only 6 related to current runs
-    assert len(timdex_dataset.dataset.files) == 6
 
 
 def test_dataset_get_filtered_dataset_with_single_nonpartition_success(
     timdex_dataset_multi_source,
 ):
-    timdex_dataset_multi_source.load()  # initial load dataset, no filters passed
-
     filtered_timdex_dataset = timdex_dataset_multi_source._get_filtered_dataset(
         run_id="abc123",
     )
@@ -211,8 +160,6 @@ def test_dataset_get_filtered_dataset_with_single_nonpartition_success(
 def test_dataset_get_filtered_dataset_with_multi_nonpartition_filters_success(
     timdex_dataset_multi_source,
 ):
-    timdex_dataset_multi_source.load()  # initial load dataset, no filters passed
-
     filtered_timdex_dataset = timdex_dataset_multi_source._get_filtered_dataset(
         timdex_record_id="alma:0",
         source="alma",
@@ -229,8 +176,6 @@ def test_dataset_get_filtered_dataset_with_multi_nonpartition_filters_success(
 def test_dataset_get_filtered_dataset_with_or_nonpartition_filters_success(
     timdex_dataset_multi_source,
 ):
-    timdex_dataset_multi_source.load()
-
     filtered_timdex_dataset = timdex_dataset_multi_source._get_filtered_dataset(
         timdex_record_id=["alma:0", "alma:1"]
     )
@@ -242,8 +187,6 @@ def test_dataset_get_filtered_dataset_with_or_nonpartition_filters_success(
 def test_dataset_get_filtered_dataset_with_run_date_str_successs(
     timdex_dataset_multi_source,
 ):
-    timdex_dataset_multi_source.load()  # initial load dataset, no filters passed
-
     filtered_timdex_dataset = timdex_dataset_multi_source._get_filtered_dataset(
         run_date="2024-12-01"
     )
@@ -253,15 +196,16 @@ def test_dataset_get_filtered_dataset_with_run_date_str_successs(
 
     # timdex_dataset_multi_source consists of single 'run_date' value
     # therefore, filtered_timdex_dataset includes all records
-    assert filtered_timdex_dataset.count_rows() == timdex_dataset_multi_source.row_count
+    assert (
+        filtered_timdex_dataset.count_rows()
+        == timdex_dataset_multi_source.dataset.count_rows()
+    )
     assert empty_timdex_dataset.count_rows() == 0
 
 
 def test_dataset_get_filtered_dataset_with_run_date_obj_success(
     timdex_dataset_multi_source,
 ):
-    timdex_dataset_multi_source.load()  # initial load dataset, no filters passed
-
     filtered_timdex_dataset = timdex_dataset_multi_source._get_filtered_dataset(
         run_date=date(2024, 12, 1)
     )
@@ -271,13 +215,14 @@ def test_dataset_get_filtered_dataset_with_run_date_obj_success(
 
     # timdex_dataset_multi_source consists of single 'run_date' value
     # therefore, filtered_timdex_dataset includes all records
-    assert filtered_timdex_dataset.count_rows() == timdex_dataset_multi_source.row_count
+    assert (
+        filtered_timdex_dataset.count_rows()
+        == timdex_dataset_multi_source.dataset.count_rows()
+    )
     assert empty_timdex_dataset.count_rows() == 0
 
 
 def test_dataset_get_filtered_dataset_with_ymd_success(timdex_dataset_multi_source):
-    timdex_dataset_multi_source.load()  # initial load dataset, no filters passed
-
     filtered_timdex_dataset = timdex_dataset_multi_source._get_filtered_dataset(
         year="2024"
     )
@@ -285,15 +230,16 @@ def test_dataset_get_filtered_dataset_with_ymd_success(timdex_dataset_multi_sour
 
     # timdex_dataset_multi_source consists of single 'run_date' value
     # therefore, filtered_timdex_dataset includes all records
-    assert filtered_timdex_dataset.count_rows() == timdex_dataset_multi_source.row_count
+    assert (
+        filtered_timdex_dataset.count_rows()
+        == timdex_dataset_multi_source.dataset.count_rows()
+    )
     assert empty_timdex_dataset.count_rows() == 0
 
 
 def test_dataset_get_filtered_dataset_with_run_date_invalid_raise_error(
     timdex_dataset_multi_source,
 ):
-    timdex_dataset_multi_source.load()  # initial load dataset, no filters passed
-
     with pytest.raises(
         TypeError,
         match=(
@@ -317,107 +263,15 @@ def test_dataset_get_s3_filesystem_success(mocker):
     assert isinstance(s3_filesystem, pa._s3fs.S3FileSystem)
 
 
-@pytest.mark.parametrize(
-    ("location_param", "expected_filesystem", "expected_source_param"),
-    [
-        ("path/to/dataset", fs.LocalFileSystem, "path/to/dataset"),
-        (
-            ["path/to/records1.parquet", "path/to/records2.parquet"],
-            fs.LocalFileSystem,
-            ["path/to/records1.parquet", "path/to/records2.parquet"],
-        ),
-        ("s3://bucket/path/to/dataset", fs.S3FileSystem, "bucket/path/to/dataset"),
-        (
-            [
-                "s3://bucket/path/to/dataset/records1.parquet",
-                "s3://bucket/path/to/dataset/records2.parquet",
-            ],
-            fs.S3FileSystem,
-            [
-                "bucket/path/to/dataset/records1.parquet",
-                "bucket/path/to/dataset/records2.parquet",
-            ],
-        ),
-    ],
-)
-@patch("timdex_dataset_api.dataset.TIMDEXDataset.get_s3_filesystem")
-def test_dataset_parse_location_success(
-    get_s3_filesystem,
-    location_param,
-    expected_filesystem,
-    expected_source_param,
-    tmp_path,
-):
-    get_s3_filesystem.return_value = fs.S3FileSystem()
-
-    location = location_param
-    expected_source = expected_source_param
-
-    if isinstance(location, str) and not location.startswith("s3://"):
-        location = str(tmp_path / location)
-        expected_source = str(tmp_path / expected_source)
-    elif isinstance(location, list) and not location[0].startswith("s3://"):
-        location = [str(tmp_path / path) for path in location]
-        expected_source = [str(tmp_path / path) for path in expected_source]
-
-    filesystem, source = TIMDEXDataset.parse_location(location)
-    assert isinstance(filesystem, expected_filesystem)
-    assert source == expected_source
-
-
-@pytest.mark.parametrize(
-    ("location_param", "expected_exception"),
-    [
-        # None is invalid location type
-        (None, TypeError),
-        # mixed local and S3 locations
-        (
-            [
-                "local/path/to/dataset/records.parquet",
-                "s3://path/to/dataset/records.parquet",
-            ],
-            ValueError,
-        ),
-    ],
-)
-@patch("timdex_dataset_api.dataset.TIMDEXDataset.get_s3_filesystem")
-def test_dataset_parse_location_error(
-    get_s3_filesystem, location_param, expected_exception, tmp_path
-):
-    get_s3_filesystem.return_value = fs.S3FileSystem()
-
-    location = location_param
-    if isinstance(location, list) and not all(
-        path.startswith("s3://") for path in location
-    ):
-        # Update the local path with tmp_path
-        location = [
-            str(tmp_path / path) if not path.startswith("s3://") else path
-            for path in location
-        ]
-
-    with pytest.raises(expected_exception):
-        _ = TIMDEXDataset.parse_location(location)
-
-
 def test_dataset_timdex_dataset_validate_success(timdex_dataset):
     assert timdex_dataset.dataset.to_table().validate() is None  # where None is valid
 
 
 def test_dataset_timdex_dataset_row_count_success(timdex_dataset):
-    assert timdex_dataset.dataset.count_rows() == timdex_dataset.row_count
-
-
-def test_dataset_timdex_dataset_row_count_missing_dataset_raise_error(
-    timdex_dataset, tmp_path
-):
-    td = TIMDEXDataset(location=str(tmp_path / "path/to/nowhere"))
-    with pytest.raises(DatasetNotLoadedError):
-        _ = td.row_count
+    assert timdex_dataset.dataset.count_rows() == timdex_dataset.dataset.count_rows()
 
 
 def test_dataset_all_records_not_current_and_not_deduped(timdex_dataset_with_runs):
-    timdex_dataset_with_runs.load()
     all_records_df = timdex_dataset_with_runs.read_dataframe()
 
     # assert counts reflect all records from dataset, no deduping
@@ -426,145 +280,6 @@ def test_dataset_all_records_not_current_and_not_deduped(timdex_dataset_with_run
     # assert run_date min/max dates align with min/max for all runs
     assert all_records_df.run_date.min() == date(2024, 12, 1)
     assert all_records_df.run_date.max() == date(2025, 2, 5)
-
-
-@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
-def test_dataset_all_current_records_deduped(timdex_dataset_with_runs):
-    timdex_dataset_with_runs.load(current_records=True)
-    all_records_df = timdex_dataset_with_runs.read_dataframe()
-
-    # assert both sources have accurate record counts for current records only
-    assert all_records_df.source.value_counts().to_dict() == {"dspace": 90, "alma": 100}
-
-    # assert only one "full" run, per source
-    assert len(all_records_df[all_records_df.run_type == "full"].run_id.unique()) == 2
-
-    # assert run_date min/max dates align with both sources min/max dates
-    assert all_records_df.run_date.min() == date(2025, 1, 1)  # both
-    assert all_records_df.run_date.max() == date(2025, 2, 5)  # dspace
-
-
-@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
-def test_dataset_source_current_records_deduped(timdex_dataset_with_runs):
-    timdex_dataset_with_runs.load(current_records=True, source="alma")
-    alma_records_df = timdex_dataset_with_runs.read_dataframe()
-
-    # assert only alma records present and correct count
-    assert alma_records_df.source.value_counts().to_dict() == {"alma": 100}
-
-    # assert only one "full" run
-    assert len(alma_records_df[alma_records_df.run_type == "full"].run_id.unique()) == 1
-
-    # assert run_date min/max dates are correct for single source
-    assert alma_records_df.run_date.min() == date(2025, 1, 1)
-    assert alma_records_df.run_date.max() == date(2025, 1, 5)
-
-
-@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
-def test_dataset_all_read_methods_get_deduplication(
-    timdex_dataset_with_runs,
-):
-    timdex_dataset_with_runs.load(current_records=True, source="alma")
-
-    full_df = timdex_dataset_with_runs.read_dataframe()
-    all_records = list(timdex_dataset_with_runs.read_dicts_iter())
-    transformed_records = list(timdex_dataset_with_runs.read_transformed_records_iter())
-
-    assert len(full_df) == len(all_records) == len(transformed_records)
-
-
-@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
-def test_dataset_current_records_no_additional_filtering_accurate_records_yielded(
-    timdex_dataset_with_runs,
-):
-    timdex_dataset_with_runs.load(current_records=True, source="alma")
-    df = timdex_dataset_with_runs.read_dataframe()
-    assert df.action.value_counts().to_dict() == {"index": 99, "delete": 1}
-
-
-@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
-def test_dataset_current_records_action_filtering_accurate_records_yielded(
-    timdex_dataset_with_runs,
-):
-    timdex_dataset_with_runs.load(current_records=True, source="alma")
-    df = timdex_dataset_with_runs.read_dataframe(action="index")
-    assert df.action.value_counts().to_dict() == {"index": 99}
-
-
-@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
-def test_dataset_current_records_index_filtering_accurate_records_yielded(
-    timdex_dataset_with_runs,
-):
-    """This is a somewhat complex test, but demonstrates that only 'current' records
-    are yielded when .load(current_records=True) is applied.
-
-    Given these runs from the fixture:
-    [
-        ...
-        (25, "alma", "2025-01-03", "daily", "index", "run-5"),   <---- filtered to
-        (10, "alma", "2025-01-04", "daily", "delete", "run-6"),  <---- influences current
-        ...
-    ]
-
-    Though we are filtering to run-5, which has 25 total records to-index, we see only 15
-    records yielded.  Why?  This is because while we have filtered to only yield from
-    run-5, run-6 had 10 deletes which made records alma:0|9 no longer "current" in run-5.
-    As we yielded records reverse chronologically, the deletes from run-6 (alma:0-alma:9)
-    "influenced" what records we would see as we continue backwards in time.
-    """
-    # with current_records=False, we get all 25 records from run-5
-    timdex_dataset_with_runs.load(current_records=False, source="alma")
-    df = timdex_dataset_with_runs.read_dataframe(run_id="run-5")
-    assert len(df) == 25
-
-    # with current_records=True, we only get 15 records from run-5
-    # because newer run-6 influenced what records are current for older run-5
-    timdex_dataset_with_runs.load(current_records=True, source="alma")
-    df = timdex_dataset_with_runs.read_dataframe(run_id="run-5")
-    assert len(df) == 15
-    assert list(df.timdex_record_id) == [
-        "alma:10",
-        "alma:11",
-        "alma:12",
-        "alma:13",
-        "alma:14",
-        "alma:15",
-        "alma:16",
-        "alma:17",
-        "alma:18",
-        "alma:19",
-        "alma:20",
-        "alma:21",
-        "alma:22",
-        "alma:23",
-        "alma:24",
-    ]
-
-
-@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
-def test_dataset_load_current_records_gets_correct_same_day_full_run(
-    timdex_dataset_same_day_runs,
-):
-    """Two full runs were performed on the same day, but 'run-2' was performed most
-    recently.  current_records=True should discover the more recent of the two 'run-2',
-    not 'run-1'."""
-    timdex_dataset_same_day_runs.load(current_records=True, run_type="full")
-    df = timdex_dataset_same_day_runs.read_dataframe()
-
-    assert list(df.run_id.unique()) == ["run-2"]
-
-
-@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
-def test_dataset_load_current_records_gets_correct_same_day_daily_runs_ordering(
-    timdex_dataset_same_day_runs,
-):
-    """Two runs were performed on 2025-01-02, but the most recent records should be from
-    run 'run-5' which are action='delete', not 'run-4' with action='index'."""
-    timdex_dataset_same_day_runs.load(current_records=True, run_type="daily")
-    first_record = next(timdex_dataset_same_day_runs.read_dicts_iter())
-
-    assert first_record["run_id"] == "run-5"
-    assert first_record["action"] == "delete"
 
 
 def test_dataset_records_data_structure_is_idempotent(timdex_dataset_with_runs):

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -1,4 +1,6 @@
-# ruff: noqa: PLR2004
+# ruff: noqa: D205, D209, PLR2004
+
+from datetime import date
 
 import pandas as pd
 import pyarrow as pa
@@ -31,7 +33,7 @@ def test_read_batches_filter_columns(timdex_dataset_multi_source):
 def test_read_batches_no_filters_gets_full_dataset(timdex_dataset_multi_source):
     batches = timdex_dataset_multi_source.read_batches_iter()
     table = pa.Table.from_batches(batches)
-    assert len(table) == timdex_dataset_multi_source.row_count
+    assert len(table) == timdex_dataset_multi_source.dataset.count_rows()
 
 
 def test_read_batches_with_filters_gets_subset_of_dataset(timdex_dataset_multi_source):
@@ -44,10 +46,10 @@ def test_read_batches_with_filters_gets_subset_of_dataset(timdex_dataset_multi_s
 
     table = pa.Table.from_batches(batches)
     assert len(table) == 1_000
-    assert len(table) < timdex_dataset_multi_source.row_count
+    assert len(table) < timdex_dataset_multi_source.dataset.count_rows()
 
     # assert loaded dataset is unchanged by filtering for a read method
-    assert timdex_dataset_multi_source.row_count == 5_000
+    assert timdex_dataset_multi_source.dataset.count_rows() == 5_000
 
 
 def test_read_dataframe_batches_yields_dataframes(timdex_dataset_multi_source):
@@ -62,7 +64,7 @@ def test_read_dataframe_reads_all_dataset_rows_after_filtering(
 ):
     df = timdex_dataset_multi_source.read_dataframe()
     assert isinstance(df, pd.DataFrame)
-    assert len(df) == timdex_dataset_multi_source.row_count
+    assert len(df) == timdex_dataset_multi_source.dataset.count_rows()
 
 
 def test_read_dicts_yields_dictionary_for_each_dataset_record(
@@ -90,3 +92,142 @@ def test_read_transformed_records_yields_parsed_dictionary(timdex_dataset_multi_
     transformed_record = next(batches)
     assert isinstance(transformed_record, dict)
     assert transformed_record == {"title": ["Hello World."]}
+
+
+@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
+def test_dataset_all_current_records_deduped(timdex_dataset_with_runs):
+    timdex_dataset_with_runs.load(current_records=True)
+    all_records_df = timdex_dataset_with_runs.read_dataframe()
+
+    # assert both sources have accurate record counts for current records only
+    assert all_records_df.source.value_counts().to_dict() == {"dspace": 90, "alma": 100}
+
+    # assert only one "full" run, per source
+    assert len(all_records_df[all_records_df.run_type == "full"].run_id.unique()) == 2
+
+    # assert run_date min/max dates align with both sources min/max dates
+    assert all_records_df.run_date.min() == date(2025, 1, 1)  # both
+    assert all_records_df.run_date.max() == date(2025, 2, 5)  # dspace
+
+
+@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
+def test_dataset_source_current_records_deduped(timdex_dataset_with_runs):
+    timdex_dataset_with_runs.load(current_records=True, source="alma")
+    alma_records_df = timdex_dataset_with_runs.read_dataframe()
+
+    # assert only alma records present and correct count
+    assert alma_records_df.source.value_counts().to_dict() == {"alma": 100}
+
+    # assert only one "full" run
+    assert len(alma_records_df[alma_records_df.run_type == "full"].run_id.unique()) == 1
+
+    # assert run_date min/max dates are correct for single source
+    assert alma_records_df.run_date.min() == date(2025, 1, 1)
+    assert alma_records_df.run_date.max() == date(2025, 1, 5)
+
+
+@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
+def test_dataset_all_read_methods_get_deduplication(
+    timdex_dataset_with_runs,
+):
+    timdex_dataset_with_runs.load(current_records=True, source="alma")
+
+    full_df = timdex_dataset_with_runs.read_dataframe()
+    all_records = list(timdex_dataset_with_runs.read_dicts_iter())
+    transformed_records = list(timdex_dataset_with_runs.read_transformed_records_iter())
+
+    assert len(full_df) == len(all_records) == len(transformed_records)
+
+
+@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
+def test_dataset_current_records_no_additional_filtering_accurate_records_yielded(
+    timdex_dataset_with_runs,
+):
+    timdex_dataset_with_runs.load(current_records=True, source="alma")
+    df = timdex_dataset_with_runs.read_dataframe()
+    assert df.action.value_counts().to_dict() == {"index": 99, "delete": 1}
+
+
+@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
+def test_dataset_current_records_action_filtering_accurate_records_yielded(
+    timdex_dataset_with_runs,
+):
+    timdex_dataset_with_runs.load(current_records=True, source="alma")
+    df = timdex_dataset_with_runs.read_dataframe(action="index")
+    assert df.action.value_counts().to_dict() == {"index": 99}
+
+
+@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
+def test_dataset_current_records_index_filtering_accurate_records_yielded(
+    timdex_dataset_with_runs,
+):
+    """This is a somewhat complex test, but demonstrates that only 'current' records
+    are yielded when .load(current_records=True) is applied.
+
+    Given these runs from the fixture:
+    [
+        ...
+        (25, "alma", "2025-01-03", "daily", "index", "run-5"),   <---- filtered to
+        (10, "alma", "2025-01-04", "daily", "delete", "run-6"),  <---- influences current
+        ...
+    ]
+
+    Though we are filtering to run-5, which has 25 total records to-index, we see only 15
+    records yielded.  Why?  This is because while we have filtered to only yield from
+    run-5, run-6 had 10 deletes which made records alma:0|9 no longer "current" in run-5.
+    As we yielded records reverse chronologically, the deletes from run-6 (alma:0-alma:9)
+    "influenced" what records we would see as we continue backwards in time.
+    """
+    # with current_records=False, we get all 25 records from run-5
+    timdex_dataset_with_runs.load(current_records=False, source="alma")
+    df = timdex_dataset_with_runs.read_dataframe(run_id="run-5")
+    assert len(df) == 25
+
+    # with current_records=True, we only get 15 records from run-5
+    # because newer run-6 influenced what records are current for older run-5
+    timdex_dataset_with_runs.load(current_records=True, source="alma")
+    df = timdex_dataset_with_runs.read_dataframe(run_id="run-5")
+    assert len(df) == 15
+    assert list(df.timdex_record_id) == [
+        "alma:10",
+        "alma:11",
+        "alma:12",
+        "alma:13",
+        "alma:14",
+        "alma:15",
+        "alma:16",
+        "alma:17",
+        "alma:18",
+        "alma:19",
+        "alma:20",
+        "alma:21",
+        "alma:22",
+        "alma:23",
+        "alma:24",
+    ]
+
+
+@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
+def test_dataset_load_current_records_gets_correct_same_day_full_run(
+    timdex_dataset_same_day_runs,
+):
+    """Two full runs were performed on the same day, but 'run-2' was performed most
+    recently.  current_records=True should discover the more recent of the two 'run-2',
+    not 'run-1'."""
+    timdex_dataset_same_day_runs.load(current_records=True, run_type="full")
+    df = timdex_dataset_same_day_runs.read_dataframe()
+
+    assert list(df.run_id.unique()) == ["run-2"]
+
+
+@pytest.mark.skip(reason="All tests for 'current' records will be reworked.")
+def test_dataset_load_current_records_gets_correct_same_day_daily_runs_ordering(
+    timdex_dataset_same_day_runs,
+):
+    """Two runs were performed on 2025-01-02, but the most recent records should be from
+    run 'run-5' which are action='delete', not 'run-4' with action='index'."""
+    timdex_dataset_same_day_runs.load(current_records=True, run_type="daily")
+    first_record = next(timdex_dataset_same_day_runs.read_dicts_iter())
+
+    assert first_record["run_id"] == "run-5"
+    assert first_record["action"] == "delete"

--- a/timdex_dataset_api/exceptions.py
+++ b/timdex_dataset_api/exceptions.py
@@ -1,9 +1,5 @@
 """timdex_dataset_api/exceptions.py"""
 
 
-class DatasetNotLoadedError(Exception):
-    """Custom exception for accessing methods requiring a loaded dataset."""
-
-
 class InvalidDatasetRecordError(Exception):
     """Custom exception for invalid DatasetRecord instances."""


### PR DESCRIPTION
_Note: this PR builds on https://github.com/MITLibraries/timdex-dataset-api/pull/159._

### Purpose and background context

This PR updates how a `TIMDEXDataset` instance is initialized.  

Formerly, initialization allowed for a `str` (root of pyarrow dataset) or a `list[str]` which was an explicit list of parquet files.  This reflected an earlier approach where direct manipulation of the parquet files loaded was used for filtering.  Now that we're moving into an architecture where we have metadata, and the dataset has more structure (e.g. `/data/records` and `/metadata`) we want the `TIMDEXDataset` to represent the TIMDEX dataset **as a whole**.  

As such, we now only allow for a `location: str` which is the root of the dataset.  A future ticket, [TIMX-529](https://mitlibraries.atlassian.net/browse/TIMX-529), will begin applying the metadata to queries, utilizing a different approach for limiting the parquet files.  

By only allowing a `str` location, and no longer _temporarily_ swapping out the dataset parquet files associated with `self.dataset`, a lot of complexity is removed.  Somewhat projecting to TIMX-529, the approach can now be summarized as:

1. Init a `TIMDEXDataset` instance with the dataset root, e.g. `s3://timdex/dataset`
2. `TIMDEXDataset` uses that location and knows the pyarrrow ETL parquet dataset is at `/dataset/data/records`, and that dataset is automatically loaded
3. `TIMDEXDatasetMetadata` _also_ gets the same location, knowing it can find its assets at `/dataset/metadata`; this is a big win for this simplification here
4. Eventually, read methods will apply parquet file "pruning" (e.g. only querying from a subset) based on metadata queries, making it unnecessary to "hot swap"  the parquet files assocated with `self.dataset`

#### Next steps:

- Rework read methods to use SQL + metadata, [TIMX-529](https://mitlibraries.atlassian.net/browse/TIMX-529)
- Merge append deltas into static DB, [TIMX-528](https://mitlibraries.atlassian.net/browse/TIMX-528)

### How can a reviewer manually see the effects of these changes?

1- Set AWS Dev `TimdexManagers` credentials

2- Set env vars:
```shell
TDA_LOG_LEVEL=DEBUG
WARNING_ONLY_LOGGERS=asyncio,botocore,urllib3,s3transfer,boto3,MARKDOWN
TIMDEX_DATASET_LOCATION=s3://timdex-extract-dev-222053980223/dataset_scratch
```

3- Start Ipython shell with `pipenv run ipython` and do some setup:
```python
import os

from timdex_dataset_api import TIMDEXDataset
from timdex_dataset_api.config import configure_dev_logger
from tests.utils import generate_sample_records

configure_dev_logger()
```

4- Create a `TIMDEXDataset` instance, noting that a pyarrow dataset is automatically loaded:
```python
td = TIMDEXDataset(os.environ["TIMDEX_DATASET_LOCATION"])
"""
...
INFO:timdex_dataset_api.dataset:Dataset successfully loaded: 's3://timdex-extract-dev-222053980223/dataset_scratch/data/records', 1.06s
...
"""
```

5- Note the removal of `.load()`, replaced by a more explicit `.load_pyarrow_dataset()` which _returns_ a dataset instance versus setting on self:
```python
pa_ds = td.load_pyarrow_dataset()
"""
INFO:timdex_dataset_api.dataset:Dataset successfully loaded: 's3://timdex-extract-dev-222053980223/dataset_scratch/data/records', 1.06s
"""

type(pa_ds)
"""
Out[3]: pyarrow._dataset.FileSystemDataset
"""
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-533

[TIMX-529]: https://mitlibraries.atlassian.net/browse/TIMX-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TIMX-529]: https://mitlibraries.atlassian.net/browse/TIMX-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ