### PR TITLE
Timx 528 merge append deltas

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """tests/conftest.py"""
 
+import shutil
 from collections.abc import Iterator
 
 import boto3
@@ -263,6 +264,26 @@ def timdex_metadata_with_deltas(
     td.write(records)
 
     return TIMDEXDatasetMetadata(timdex_dataset_with_runs.location)
+
+
+@pytest.fixture
+def timdex_metadata_merged_deltas(
+    tmp_path, timdex_metadata_with_deltas, timdex_dataset_with_runs
+):
+    """TIMDEXDatasetMetadata after merging append deltas to static database file."""
+    # copy directory of a dataset with runs
+    dataset_location = str(tmp_path / "cloned_dataset_with_runs/")
+    shutil.copytree(timdex_metadata_with_deltas.location, dataset_location)
+
+    # clone dataset with runs using new dataset location
+    td = TIMDEXDataset(dataset_location, config=timdex_dataset_with_runs.config)
+
+    # clone metadata and merge append deltas
+    metadata = TIMDEXDatasetMetadata(td.location)
+    metadata.merge_append_deltas()
+    metadata.refresh()
+
+    return metadata
 
 
 # ================================================================================

--- a/tests/test_s3client.py
+++ b/tests/test_s3client.py
@@ -42,6 +42,22 @@ def test_split_s3_uri_invalid():
         client._split_s3_uri("timdex/path/to/file.txt")
 
 
+def test_list_objects(s3_bucket_mocked, tmp_path):
+    client = S3Client()
+
+    # Create a test file
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("test content")
+
+    # Upload the file
+    s3_uri = "s3://timdex/metadata/append_deltas/test.txt"
+    client.upload_file(test_file, s3_uri)
+
+    # Verify list of objects
+    s3_prefix = "s3://timdex/metadata/append_deltas"
+    assert client.list_objects(s3_prefix) == ["metadata/append_deltas/test.txt"]
+
+
 def test_upload_download_file(s3_bucket_mocked, tmp_path):
     """Test upload_file and download_file methods."""
     client = S3Client()

--- a/timdex_dataset_api/metadata.py
+++ b/timdex_dataset_api/metadata.py
@@ -396,7 +396,8 @@ class TIMDEXDatasetMetadata:
             create or replace view metadata.append_deltas as (
                 select *
                 from read_parquet(
-                    '{self.append_deltas_path}/*.parquet'
+                    '{self.append_deltas_path}/*.parquet',
+                    filename = 'append_delta_filename'
                 )
             );
             """
@@ -414,14 +415,17 @@ class TIMDEXDatasetMetadata:
 
     def _create_records_union_view(self, conn: DuckDBPyConnection) -> None:
         logger.debug("creating view of unioned records")
+
         conn.execute(
-            """
+            f"""
             create or replace view metadata.records as
             (
-                select *
+                select
+                    {','.join(ORDERED_METADATA_COLUMN_NAMES)}
                 from static_db.records
                 union all
-                select *
+                select
+                    {','.join(ORDERED_METADATA_COLUMN_NAMES)}
                 from metadata.append_deltas
             );
             """

--- a/timdex_dataset_api/utils.py
+++ b/timdex_dataset_api/utils.py
@@ -59,6 +59,12 @@ class S3Client:
                 return False
             raise
 
+    def list_objects(self, s3_prefix: str) -> list[str]:
+        bucket, _ = self._split_s3_uri(s3_prefix)
+        objects = [obj.key for obj in self.resource.Bucket(bucket).objects.all()]
+        logger.debug(f"Found {len(objects)} objects in {s3_prefix}: {objects}")
+        return objects
+
     def download_file(self, s3_uri: str, local_path: str | pathlib.Path) -> None:
         bucket, key = self._split_s3_uri(s3_uri)
         local_path = pathlib.Path(local_path)


### PR DESCRIPTION
### Purpose and background context

TDA requires a method to support regular merging of append deltas into the static `metadata.duckdb` database file as new rows and then deletes (the append deltas) once merged. This work is encapsulated in the [second commit](https://github.com/MITLibraries/timdex-dataset-api/pull/163/commits/8cee97d65a578e83d677420a472058fa3b027259). The updates in the [first commit](https://github.com/MITLibraries/timdex-dataset-api/pull/163/commits/bc33d6f221bce58e5a614625954abe8439a1952d) was a prerequisite for the merging method.

### How can a reviewer manually see the effects of these changes?

For review purposes, the [added unit test](https://github.com/MITLibraries/timdex-dataset-api/pull/163/files#diff-f49ce5cf2ce23f6922b7add17ca149482d190f1c2b5892c5d1d55a28497c5556R267-R289) provides a detailed overview of the method's functionality.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-528