### PR TITLE
TIMX 540 - adjust AWS credential chain for ECS context

### DIFF
--- a/timdex_dataset_api/metadata.py
+++ b/timdex_dataset_api/metadata.py
@@ -194,7 +194,6 @@ class TIMDEXDatasetMetadata:
                 create or replace secret aws_s3_secret (
                     type s3,
                     provider credential_chain,
-                    chain 'sso;env;config',
                     refresh true
                     {scope_str}
                 );

--- a/timdex_dataset_api/metadata.py
+++ b/timdex_dataset_api/metadata.py
@@ -161,6 +161,14 @@ class TIMDEXDatasetMetadata:
         If a scope is provided, e.g. an S3 URI prefix like 's3://timdex', set a scope
         parameter in the config.  Else, leave it blank.
         """
+        # install httpfs extension
+        conn.execute(
+            """
+            install httpfs;
+            load httpfs;
+            """
+        )
+
         # establish scope string
         scope_str = f", scope '{scope}'" if scope else ""
 


### PR DESCRIPTION
### Purpose and background context

Small tweaks to AWS secret creation in DuckDB context after testing in ECS context.  

In short: the **removal** of `chain` allows DuckDB to try all methods, e.g. `sso`, `env`, `instance`, etc., until it finds credentials.  Previously I had a list of types I thought would work, but `instance` was the magic one for ECS Fargate tasks!

### How can a reviewer manually see the effects of these changes?

Successful run in Dev 1 as part of StepFunction ([link](https://222053980223-jlfmfcb7.us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/v2/executions/details/arn:aws:states:us-east-1:222053980223:execution:timdex-ingest-dev:ab1a9d3b-54b7-44cf-880c-959ac3e0507c)):

<img width="503" height="291" alt="Screenshot 2025-08-14 at 1 17 05 PM" src="https://github.com/user-attachments/assets/0515d868-2b16-4532-8bfa-c0a130d6ddea" />

Ultimatley the run failed, but that was expected; it was the success of Transmog here that was important 😎.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: Transmog, pipeline lambda, and TIM should be able to DuckDB connect to S3 assets

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-540