### PR TITLE
TIMX 541 - handle missing HOME env in AWS Lambda

### DIFF
--- a/timdex_dataset_api/dataset.py
+++ b/timdex_dataset_api/dataset.py
@@ -226,8 +226,8 @@ class TIMDEXDataset:
     def setup_duckdb_context(self) -> DuckDBPyConnection:
         """Create a DuckDB connection that metadata and data query and retrieval.
 
-        This relies on TIMDEXDatasetMetadata.setup_duckdb_context() to produce a DuckDB
-        connection that has all metadata already created.
+        This method extends TIMDEXDatasetMetadata's pre-existing DuckDB connection, adding
+        a 'data' schema and any other configurations needed.
         """
         start_time = time.perf_counter()
 


### PR DESCRIPTION
~~*NOTE: extends https://github.com/MITLibraries/timdex-dataset-api/pull/164.*~~

### Purpose and background context

Provide location for DuckDB extensions if HOME not set.

**Why these changes are being introduced:**

In the AWS Lambda context, the `HOME` env var is empty string `''`.  DuckDB has a canned error response for this, suggesting to, `"Specify a home directory using the SET home_directory='/path/to/dir' option"`.

**How this addresses that need:**

If `HOME` is unset or empty string, set an explicit secret and extension directory at `/tmp/.duckdb/*` locations.

### How can a reviewer manually see the effects of these changes?

Successful run in Dev 1 as part of StepFunction ([link](https://222053980223-jlfmfcb7.us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/v2/executions/details/arn:aws:states:us-east-1:222053980223:execution:timdex-ingest-dev:c5e383a6-5e3f-476b-9351-b9e3b3869806)):

<img width="540" height="293" alt="Screenshot 2025-08-14 at 2 57 04 PM" src="https://github.com/user-attachments/assets/387c71f7-0f15-4d59-875f-4cfa94341c6c" />

Ultimatley the run failed, but that was expected; it was the success of Lambdas:Load step here that was important 😎.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: AWS Lambda will successfully setup DuckDB context

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-541

