### PR TITLE
TIMX 543 - Optimize current records metadata queries and data retreival

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,7 +113,7 @@ def timdex_dataset_multi_source(tmp_path_factory) -> TIMDEXDataset:
         )
 
     # ensure static metadata database exists for read methods
-    dataset.metadata.recreate_static_database_file()
+    dataset.metadata.rebuild_dataset_metadata()
     dataset.metadata.refresh()
 
     return dataset
@@ -223,7 +223,7 @@ def timdex_dataset_same_day_runs(tmp_path) -> TIMDEXDataset:
 def timdex_metadata(timdex_dataset_with_runs) -> TIMDEXDatasetMetadata:
     """TIMDEXDatasetMetadata with static database file created."""
     metadata = TIMDEXDatasetMetadata(timdex_dataset_with_runs.location)
-    metadata.recreate_static_database_file()
+    metadata.rebuild_dataset_metadata()
     metadata.refresh()
     return metadata
 
@@ -233,7 +233,7 @@ def timdex_dataset_with_runs_with_metadata(
     timdex_dataset_with_runs,
 ) -> TIMDEXDataset:
     """TIMDEXDataset with runs and static metadata created for read tests."""
-    timdex_dataset_with_runs.metadata.recreate_static_database_file()
+    timdex_dataset_with_runs.metadata.rebuild_dataset_metadata()
     timdex_dataset_with_runs.metadata.refresh()
     return timdex_dataset_with_runs
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -43,7 +43,7 @@ def test_tdm_s3_dataset_structure_properties(s3_bucket_mocked):
 
 def test_tdm_create_metadata_database_file_success(caplog, timdex_metadata_empty):
     caplog.set_level("DEBUG")
-    timdex_metadata_empty.recreate_static_database_file()
+    timdex_metadata_empty.rebuild_dataset_metadata()
 
 
 def test_tdm_init_metadata_file_found_success(timdex_metadata):

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -276,3 +276,9 @@ def test_dataset_load_current_records_gets_correct_same_day_daily_runs_ordering(
     # just assert it's one of the daily runs
     assert first_record["run_id"] in {"run-4", "run-5"}
     assert first_record["action"] in {"index", "delete"}
+
+
+def test_read_batches_iter_limit_returns_n_rows(timdex_dataset_multi_source):
+    batches = timdex_dataset_multi_source.read_batches_iter(limit=10)
+    table = pa.Table.from_batches(batches)
+    assert len(table) == 10

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -254,7 +254,7 @@ def test_dataset_load_current_records_gets_correct_same_day_full_run(
     timdex_dataset_same_day_runs,
 ):
     # ensure metadata exists for this dataset
-    timdex_dataset_same_day_runs.metadata.recreate_static_database_file()
+    timdex_dataset_same_day_runs.metadata.rebuild_dataset_metadata()
     timdex_dataset_same_day_runs.metadata.refresh()
     df = timdex_dataset_same_day_runs.read_dataframe(
         table="current_records", run_type="full"
@@ -265,7 +265,7 @@ def test_dataset_load_current_records_gets_correct_same_day_full_run(
 def test_dataset_load_current_records_gets_correct_same_day_daily_runs_ordering(
     timdex_dataset_same_day_runs,
 ):
-    timdex_dataset_same_day_runs.metadata.recreate_static_database_file()
+    timdex_dataset_same_day_runs.metadata.rebuild_dataset_metadata()
     timdex_dataset_same_day_runs.metadata.refresh()
     first_record = next(
         timdex_dataset_same_day_runs.read_dicts_iter(

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -125,8 +125,8 @@ def test_read_batches_where_and_dataset_filters_are_combined(timdex_dataset_mult
     [
         "SELECT * FROM current_records WHERE source = 'libguides'",
         "FROM records WHERE source = 'libguides'",
-        "source = 'libguides';",
-        " run_date = '2024-12-01';  ",
+        "ORDER BY timdex_record_id",
+        "LIMIT 3",
     ],
 )
 def test_read_batches_where_rejects_non_predicate_sql(

--- a/timdex_dataset_api/__init__.py
+++ b/timdex_dataset_api/__init__.py
@@ -4,7 +4,7 @@ from timdex_dataset_api.dataset import TIMDEXDataset
 from timdex_dataset_api.metadata import TIMDEXDatasetMetadata
 from timdex_dataset_api.record import DatasetRecord
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 
 __all__ = [
     "DatasetRecord",

--- a/timdex_dataset_api/dataset.py
+++ b/timdex_dataset_api/dataset.py
@@ -387,7 +387,6 @@ class TIMDEXDataset:
         metadata_time = time.perf_counter()
         meta_query = self.metadata.build_meta_query(table, limit, where, **filters)
         meta_df = self.metadata.conn.query(meta_query).to_df()
-        meta_df = meta_df.sort_values(by=["filename", "run_record_offset"])
         logger.debug(
             f"Metadata query identified {len(meta_df)} rows, "
             f"across {len(meta_df.filename.unique())} parquet files, "

--- a/timdex_dataset_api/dataset.py
+++ b/timdex_dataset_api/dataset.py
@@ -143,6 +143,10 @@ class TIMDEXDataset:
     def data_records_root(self) -> str:
         return f"{self.location.removesuffix('/')}/data/records"  # type: ignore[union-attr]
 
+    def refresh(self) -> None:
+        """Fully reload TIMDEXDataset instance."""
+        self.__init__(self.location)  # type: ignore[misc]
+
     def create_data_structure(self) -> None:
         """Ensure ETL records data structure exists in TIMDEX dataset."""
         if self.location_scheme == "file":

--- a/timdex_dataset_api/metadata.py
+++ b/timdex_dataset_api/metadata.py
@@ -476,7 +476,7 @@ class TIMDEXDatasetMetadata:
                     where r.run_timestamp >= f.last_full_ts
                 ),
 
-                -- CTE of records ranked by run_timestamp, with tie breaker
+                -- CTE of records ranked by run_timestamp
                 cr_ranked_records as (
                     select
                         r.*,

--- a/timdex_dataset_api/metadata.py
+++ b/timdex_dataset_api/metadata.py
@@ -612,7 +612,11 @@ class TIMDEXDatasetMetadata:
         )
 
     def build_meta_query(
-        self, table: str, where: str | None, **filters: Unpack["DatasetFilters"]
+        self,
+        table: str,
+        limit: int | None,
+        where: str | None,
+        **filters: Unpack["DatasetFilters"],
     ) -> str:
         """Build SQL query using SQLAlchemy against metadata schema tables and views."""
         sa_table = self.get_sa_table(table)
@@ -637,6 +641,10 @@ class TIMDEXDatasetMetadata:
         ).select_from(sa_table)
         if combined is not None:
             stmt = stmt.where(combined)
+
+        # apply limit if present
+        if limit:
+            stmt = stmt.limit(limit)
 
         # using DuckDB dialect, compile to SQL string
         compiled = stmt.compile(

--- a/timdex_dataset_api/metadata.py
+++ b/timdex_dataset_api/metadata.py
@@ -443,6 +443,14 @@ class TIMDEXDatasetMetadata:
         This metadata view includes only the most current version of each record in the
         dataset.  With the metadata provided from this view, we can streamline data
         retrievals in TIMDEXDataset read methods.
+
+        For performance reasons, the final view reads from a DuckDB temporary table that
+        is constructed, "temp.main.current_records".  Because our connection is in memory,
+        the data in this temporary table is mostly in memory but has the ability to spill
+        to disk if we risk getting too close to our memory constraints.  We explicitly
+        set the temporary location on disk for DuckDB at "/tmp" to play nice with contexts
+        like AWS ECS or Lambda, where sometimes the $HOME env var is missing; DuckDB
+        often tries to utilize the user's home directory and this works around that.
         """
         logger.info("creating view of current records metadata")
 


### PR DESCRIPTION
### Purpose and background context

This PR makes some improvements to metadata queries and data retrieval for "current" records, recalling that a "current" record is the most recent version of a `timdex_record_id` in the dataset.

While working on a Marimo notebook that was making quite a few queries against `metadata.current_records`, there was often a 8-10 second delay before results started streaming in.  This was mostly due to how the `TIMDEXDatasetMetadata` class constructed DuckDB tables and views for current records.

The most impactful change is the decision to change the DuckDB asset `metadata.current_records` from a **view** into a [**temporary table**](https://duckdb.org/docs/stable/sql/statements/create_table.html#temporary-tables).  This is implemented by a [rewrite of `TIMDEXDatasetMetadata. _create_current_records_view()`](https://github.com/MITLibraries/timdex-dataset-api/pull/168/commits/25d443019b03af503d99857264f60ca0fad8aacf#diff-248bd5777a91fa90faf6756abf55873d051961692822f40d2db57f11c147671aL416-L468).

By materializing the "current" records metadata to a temporary table -- which actively loads into memory, but will spill to disk if memory constraints are reached -- we get orders of magnitude faster current records queries.

We may need  to revisit this approach if we find ourselves with 25-50 million "current" records, but that is likely a long ways off in the TIMDEX ecosystem.

**NOTE**: it feels worth mentioning one of the strengths of the current DuckDB context approach.  This entire change was 100% DuckDB SQL.  There are relatively no moving parts in python code or data retrieval needed, this was just some refactoring of SQL tables, views, and approaches.  While I'm confident this is an _improvement_ to the current "current" records approach, it does not prohibit us from future improvements and changes. 

The remaining commits do a little cleanup of method naming, and add a `LIMIT` clause when reading records, but they are pretty minor in comparison.

### How can a reviewer manually see the effects of these changes?

1- Set Dev1 AWS `TimdexManagers` credentials in terminal and set env vars:
```shell
TDA_LOG_LEVEL=DEBUG
WARNING_ONLY_LOGGERS=asyncio,botocore,urllib3,s3transfer,boto3,MARKDOWN
TIMDEX_DATASET_LOCATION=s3://timdex-extract-dev-222053980223/dataset_scratch/prod-clone
```

2- Open Ipython shell
```shell
pipenv run ipython
```

3- Load a `TIMDEXDataset` instance:
```python
import os

from timdex_dataset_api import TIMDEXDataset
from timdex_dataset_api.config import configure_dev_logger

configure_dev_logger()

td = TIMDEXDataset(os.environ["TIMDEX_DATASET_LOCATION"])
```

Note that the initial load is a bit slower, but still quite reasonable for connecting to a remote data lake architecture.  We may want to explore the ability to load a `TIMDEXDataset` instance _without_ some of these read capabilities, e.g. when only performing writes (e.g. Transmogrifier), but that feels like an optimiziation for a later time.

4- Perform a metadatda query that formerly took anywhere from 15-20 seconds:
```python
df = td.conn.query("""select * from metadata.current_records where source='alma' and action='index';""").to_df()
print(len(df))
#  3960267
```

5- Retrieve data that relies on current records (can `ctrl + c` to kill early):
```python
for _ in td.read_batches_iter(table='current_records', columns=['timdex_record_id','transformed_record'], source='alma', action='index'):
    pass
# ...
# DEBUG:timdex_dataset_api.dataset:Metadata query identified 3960267 rows, across 213 parquet files, elapsed: 4.23s
# ...
# ...
```

The thing to note here is the metadata query is quick, about 4.23 seconds.  With that quick and complete, we can move into yielding data quicker.

6- Lastly, the 'ole needle-in-a-haystack query to demonstrate the real benefit of this query:
```python
df = td.read_dataframe(table='current_records', source='libguides', action='index')
# ...
# DEBUG:timdex_dataset_api.dataset:Metadata query identified 372 rows, across 64 parquet files, elapsed: 0.04s
# DEBUG:timdex_dataset_api.dataset:read_batches_iter batch 1, yielded: 372 @ 68 records/second, total yielded: 372
# DEBUG:timdex_dataset_api.dataset:read_batches_iter() elapsed: 5.48s
```

Two things to note here:
- a _very_ quick metadata query, around 0.04s
- a _very_ quick data retrieval, even across 64 distinct parquet files

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: faster current records querying and data retreival!

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-543
