### PR TITLE
TIMX 543 - keyset pagination for read methods

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,7 +114,7 @@ def timdex_dataset_multi_source(tmp_path_factory) -> TIMDEXDataset:
 
     # ensure static metadata database exists for read methods
     dataset.metadata.rebuild_dataset_metadata()
-    dataset.metadata.refresh()
+    dataset.refresh()
 
     return dataset
 
@@ -234,7 +234,7 @@ def timdex_dataset_with_runs_with_metadata(
 ) -> TIMDEXDataset:
     """TIMDEXDataset with runs and static metadata created for read tests."""
     timdex_dataset_with_runs.metadata.rebuild_dataset_metadata()
-    timdex_dataset_with_runs.metadata.refresh()
+    timdex_dataset_with_runs.refresh()
     return timdex_dataset_with_runs
 
 

--- a/timdex_dataset_api/__init__.py
+++ b/timdex_dataset_api/__init__.py
@@ -4,7 +4,7 @@ from timdex_dataset_api.dataset import TIMDEXDataset
 from timdex_dataset_api.metadata import TIMDEXDatasetMetadata
 from timdex_dataset_api.record import DatasetRecord
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 
 __all__ = [
     "DatasetRecord",


### PR DESCRIPTION
### Purpose and background context

For all read methods, the former approach was to perform a metadata query and store the entire results in memory, then loop through chunks of that metadata and build SQL queries to perform data retrieval.  Even for metadata queries that may bring back 3-4 million results, this worked, but there is an upper limit.

Ideally, we would perform all of our queries -- metadata and data -- in chunks to ease memory pressure.  And in some cases, this can increase performance.

This reworks the [base `read_batches_iter()` method](https://github.com/MITLibraries/timdex-dataset-api/pull/169/files#diff-fb40971da01d2dcbf97cdad92e2c3f6656d1eaa201505a2f9074e5d52e452142L357-L423) to perform smaller, chunked metadata queries.  To paginate the results, instead of using the slow `LIMIT` / `OFFSET` approach, we use [keyset pagination](https://learn.microsoft.com/en-us/ef/core/querying/pagination#keyset-pagination), which means we can look for values greater than a tuple of values that are ordered. This is often the preferred way to perform paginated querying when you have nicely ordered columns.

In support of this, we ask the [method `_iter_meta_chunks()`](https://github.com/MITLibraries/timdex-dataset-api/pull/169/files#diff-fb40971da01d2dcbf97cdad92e2c3f6656d1eaa201505a2f9074e5d52e452142L425-R499) to do substantially more work, but less work elsewhere.

In support of this, we also begin hashing the `filename` and `run_id` columns for ordering, providing almost an order magnitude speedup. The performance penalty for creating the hash is offset by the speedup of ordering integers versus very long strings.

The net effect is no changes to the input/ouput signatures of the read methods, but improved memory usage and performance.

### How can a reviewer manually see the effects of these changes?

The following will perform some individual record retreival and bulk record retrieval, demonstrating that read operations are essentially _as_ quick, though sometimes quicker, than the previous single metadata pull.  It's difficutl to compare directly in this PR without branch hopping, but lots of testing has been done to confirm it's as quick but much more memory effecient.

1- Set Dev1 AWS `TimdexManagers` credentials in terminal and set env vars:
```shell
TDA_LOG_LEVEL=DEBUG
WARNING_ONLY_LOGGERS=asyncio,botocore,urllib3,s3transfer,boto3,MARKDOWN
TIMDEX_DATASET_LOCATION=s3://timdex-extract-dev-222053980223/dataset_scratch/prod-clone
```

2- Open Ipython shell
```shell
pipenv run ipython
```

3- Load a `TIMDEXDataset` instance:
```python
import os

from timdex_dataset_api import TIMDEXDataset
from timdex_dataset_api.config import configure_dev_logger

configure_dev_logger()

td = TIMDEXDataset(os.environ["TIMDEX_DATASET_LOCATION"])
```

4- Perform a "needle in a haystack" query that finds all versions of three records with lots of versions:
```python
df = td.read_dataframe(
    table="records",
    columns=["timdex_record_id", "transformed_record"],
    timdex_record_id=[
        "aspace:repositories-2-resources-1350",
        "libguides:guides-1385096",
        "alma:990024041390106761",
    ],
)
"""
DEBUG:timdex_dataset_api.dataset:read_batches_iter batch 1, yielded: 114 @ 16 records/second, total yielded: 114
DEBUG:timdex_dataset_api.dataset:read_batches_iter() elapsed: 6.78s
"""
```

Note that the logging has changed slightly, given what we know and when we know it, but this particularly query is retrieving 114 records from 114 parquet files!  That is good and fast projection.

5- Perform some deep pagination, getting 500k `timdex_record_id`'s for current `alma` records:
```python
for batch in td.read_batches_iter(
        table="current_records",
        columns=["timdex_record_id"],
        source="alma",
        action="index",
        limit=500_000,
):
    pass
"""
DEBUG:timdex_dataset_api.dataset:read_batches_iter batch 1, yielded: 100000 @ 53022 records/second, total yielded: 100000
DEBUG:timdex_dataset_api.dataset:read_batches_iter batch 2, yielded: 100000 @ 25097 records/second, total yielded: 200000
DEBUG:timdex_dataset_api.dataset:read_batches_iter batch 3, yielded: 100000 @ 36010 records/second, total yielded: 300000
DEBUG:timdex_dataset_api.dataset:read_batches_iter batch 4, yielded: 100000 @ 17977 records/second, total yielded: 400000
DEBUG:timdex_dataset_api.dataset:read_batches_iter batch 5, yielded: 100000 @ 43077 records/second, total yielded: 500000
DEBUG:timdex_dataset_api.dataset:read_batches_iter() elapsed: 22.32s
"""
```

6- Increase the metadata <--> data join size and repeat the last deep pagination:
```python
td.config.duckdb_join_batch_size = 500_000

for batch in td.read_batches_iter(
        table="current_records",
        columns=["timdex_record_id"],
        source="alma",
        action="index",
        limit=500_000,
):
    pass
"""
DEBUG:timdex_dataset_api.dataset:read_batches_iter batch 1, yielded: 500000 @ 56889 records/second, total yielded: 500000
DEBUG:timdex_dataset_api.dataset:read_batches_iter() elapsed: 10.36s
"""
```

Note the speed increase!  There is also a memory increase, but it's not substantial.  Roughly speaking, between the "join" size of metadata <--> data and the "read chunk" size which is how many records we stream back from DuckDB, we have quite a bit of control over the data flow that will serve us well going forward.  Current default configurations are slightly conservative, but more than sufficient for our purposes.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-543