### PR TITLE
Bump TDA version

### DIFF
--- a/timdex_dataset_api/__init__.py
+++ b/timdex_dataset_api/__init__.py
@@ -4,7 +4,7 @@ from timdex_dataset_api.dataset import TIMDEXDataset
 from timdex_dataset_api.metadata import TIMDEXDatasetMetadata
 from timdex_dataset_api.record import DatasetRecord
 
-__version__ = "3.2.0"
+__version__ = "3.3.0"
 
 __all__ = [
     "DatasetRecord",


### PR DESCRIPTION
### Purpose and background context

Bumps TDA version to `3.3`.  This ensures any installs will pickup this new version with DuckDB pinned.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- None
