### PR TITLE
Pin duckdb version in pyproject.toml for uv builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "attrs",
     "boto3",
-    "duckdb",
+    "duckdb==1.3.2",
     "duckdb_engine",
     "pandas",
     "pyarrow",

--- a/timdex_dataset_api/__init__.py
+++ b/timdex_dataset_api/__init__.py
@@ -4,7 +4,7 @@ from timdex_dataset_api.dataset import TIMDEXDataset
 from timdex_dataset_api.metadata import TIMDEXDatasetMetadata
 from timdex_dataset_api.record import DatasetRecord
 
-__version__ = "3.3.0"
+__version__ = "3.4.0"
 
 __all__ = [
     "DatasetRecord",


### PR DESCRIPTION
### Purpose and background context

Most TIMDEX components use `pipenv` to install TDA.  But for applications that use `uv`, e.g. Marimo notebooks, we need to also pin `duckdb` in the `pyproject.toml` file.

 Note: TDA is fairly unique for us as an installable python library.  These kind of awkward edges will likely smooth out as we transition fully to `uv`.

Update: it's possible that both `pipenv` and `uv` use the `pyproject.toml` file for dependencies when installing TDA from github.  Either way, it's confirmed that updating `pyproject.toml` with the `duckdb` pinning ensures we get the right version when TDA is installed.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- None
