### PR TITLE
USE 531 - Add "fulltexts" data type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "timdex_dataset_api"
-version = "5.0.1"
+version = "5.1.0"
 description = "Python library for interacting with a TIMDEX parquet dataset"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,11 +10,14 @@ import pytest
 from tests.utils import (
     generate_sample_embeddings,
     generate_sample_embeddings_for_run,
+    generate_sample_fulltexts,
+    generate_sample_fulltexts_for_run,
     generate_sample_records,
 )
 from timdex_dataset_api import TIMDEXDataset
-from timdex_dataset_api.data_types import TIMDEXEmbeddings
+from timdex_dataset_api.data_types import TIMDEXEmbeddings, TIMDEXFulltexts
 from timdex_dataset_api.data_types.embeddings import DatasetEmbedding
+from timdex_dataset_api.data_types.fulltexts import DatasetFulltext
 from timdex_dataset_api.data_types.records import DatasetRecord
 from timdex_dataset_api.dataset import TIMDEXDatasetConfig
 from timdex_dataset_api.metadata import TIMDEXDatasetMetadata
@@ -339,10 +342,64 @@ def timdex_dataset_for_embeddings_views(timdex_dataset_empty) -> TIMDEXDataset:
     - orange: full run with 10 records + daily run with 5 records
     - lemon: full run with 10 records + daily run with 5 records
     """
-    timdex_dataset_dataset = timdex_dataset_empty
+    return _dataset_for_bolt_on_view_tests(timdex_dataset_empty)
 
+
+# ================================================================================
+# Dataset Fulltexts Fixtures
+# ================================================================================
+@pytest.fixture
+def timdex_fulltexts_with_runs(timdex_dataset_empty) -> TIMDEXFulltexts:
+    """TIMDEXFulltexts with multiple runs.
+
+    Also writes matching records and rebuilds metadata so fulltexts queries
+    can join to metadata.records.
+    """
+    timdex_dataset = timdex_dataset_empty
+
+    # write matching records for fulltexts
+    timdex_dataset.records.write(
+        generate_sample_records(100, source="alma", run_id="abc123"),
+        write_append_deltas=False,
+    )
+    timdex_dataset.records.write(
+        generate_sample_records(50, source="alma", run_id="def456"),
+        write_append_deltas=False,
+    )
+
+    # reload TIMDEXDataset instance and build metadata
+    timdex_dataset.metadata.rebuild_dataset_metadata()
+    timdex_dataset = TIMDEXDataset(timdex_dataset.location)
+
+    # write fulltexts
+    timdex_dataset.fulltexts.write(
+        generate_sample_fulltexts_for_run(timdex_dataset, run_id="abc123")
+    )
+    timdex_dataset.fulltexts.write(
+        generate_sample_fulltexts_for_run(timdex_dataset, run_id="def456")
+    )
+
+    # rebuild metadata to include fulltexts, then reload
+    timdex_dataset.metadata.rebuild_dataset_metadata()
+    return TIMDEXDataset(timdex_dataset_empty.location).fulltexts
+
+
+@pytest.fixture
+def timdex_dataset_for_fulltexts_views(timdex_dataset_empty) -> TIMDEXDataset:
+    """TIMDEXDataset with records for testing fulltexts views.
+
+    Creates three scenarios to test DuckDB views:
+    - apple: single full run with 10 records
+    - orange: full run with 10 records + daily run with 5 records
+    - lemon: full run with 10 records + daily run with 5 records
+    """
+    return _dataset_for_bolt_on_view_tests(timdex_dataset_empty)
+
+
+def _dataset_for_bolt_on_view_tests(timdex_dataset: TIMDEXDataset) -> TIMDEXDataset:
+    """Create a dataset with records for bolt-on data type view tests."""
     # scenario 1: apple - single full run
-    timdex_dataset_dataset.records.write(
+    timdex_dataset.records.write(
         generate_sample_records(
             num_records=10,
             source="apple",
@@ -354,7 +411,7 @@ def timdex_dataset_for_embeddings_views(timdex_dataset_empty) -> TIMDEXDataset:
     )
 
     # scenario 2: orange - full run + daily run
-    timdex_dataset_dataset.records.write(
+    timdex_dataset.records.write(
         generate_sample_records(
             num_records=10,
             source="orange",
@@ -364,7 +421,7 @@ def timdex_dataset_for_embeddings_views(timdex_dataset_empty) -> TIMDEXDataset:
         ),
         write_append_deltas=False,
     )
-    timdex_dataset_dataset.records.write(
+    timdex_dataset.records.write(
         generate_sample_records(
             num_records=5,
             source="orange",
@@ -375,8 +432,8 @@ def timdex_dataset_for_embeddings_views(timdex_dataset_empty) -> TIMDEXDataset:
         write_append_deltas=False,
     )
 
-    # scenario 3: lemon - full run + daily run (daily will be embedded twice)
-    timdex_dataset_dataset.records.write(
+    # scenario 3: lemon - full run + daily run
+    timdex_dataset.records.write(
         generate_sample_records(
             num_records=10,
             source="lemon",
@@ -386,7 +443,7 @@ def timdex_dataset_for_embeddings_views(timdex_dataset_empty) -> TIMDEXDataset:
         ),
         write_append_deltas=False,
     )
-    timdex_dataset_dataset.records.write(
+    timdex_dataset.records.write(
         generate_sample_records(
             num_records=5,
             source="lemon",
@@ -398,10 +455,10 @@ def timdex_dataset_for_embeddings_views(timdex_dataset_empty) -> TIMDEXDataset:
     )
 
     # rebuild metadata so records can be queried
-    timdex_dataset_dataset.metadata.rebuild_dataset_metadata()
+    timdex_dataset.metadata.rebuild_dataset_metadata()
 
     # reload dataset to work around bug
-    return TIMDEXDataset(timdex_dataset_dataset.location)
+    return TIMDEXDataset(timdex_dataset.location)
 
 
 # ================================================================================
@@ -437,5 +494,21 @@ def sample_embeddings_generator():
 
     def _generate(num_embeddings: int = 100, **kwargs) -> Iterator[DatasetEmbedding]:
         return generate_sample_embeddings(num_embeddings=num_embeddings, **kwargs)
+
+    return _generate
+
+
+@pytest.fixture
+def sample_fulltexts() -> Iterator[DatasetFulltext]:
+    """Generate 100 sample fulltexts with default parameters."""
+    return generate_sample_fulltexts(num_fulltexts=100)
+
+
+@pytest.fixture
+def sample_fulltexts_generator():
+    """Factory fixture for generating custom sample fulltexts."""
+
+    def _generate(num_fulltexts: int = 100, **kwargs) -> Iterator[DatasetFulltext]:
+        return generate_sample_fulltexts(num_fulltexts=num_fulltexts, **kwargs)
 
     return _generate

--- a/tests/test_fulltexts.py
+++ b/tests/test_fulltexts.py
@@ -1,0 +1,630 @@
+# ruff: noqa: PLR2004
+
+import hashlib
+import os
+from datetime import UTC, datetime
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.dataset as ds
+import pytest
+
+from tests.utils import generate_sample_fulltexts_for_run, generate_sample_records
+from timdex_dataset_api import TIMDEXDataset
+from timdex_dataset_api.data_types import TIMDEXFulltexts
+from timdex_dataset_api.data_types.fulltexts import DatasetFulltext
+
+FULLTEXTS_AVAILABLE_COLUMNS_SET = set(TIMDEXFulltexts.AVAILABLE_READ_COLUMNS)
+
+
+def test_dataset_fulltext_init():
+    values = {
+        "timdex_record_id": "alma:123",
+        "run_id": "test-run-1",
+        "run_record_offset": 0,
+        "fulltext_timestamp": "2024-12-01T10:00:00+00:00",
+        "fulltext": b"Sample fulltext content.",
+    }
+    fulltext = DatasetFulltext(**values)
+
+    assert fulltext
+    assert fulltext.timdex_record_id == "alma:123"
+    assert fulltext.fulltext_timestamp == datetime(2024, 12, 1, 10, 0, tzinfo=UTC)
+    assert fulltext.fulltext_md5 is None
+    assert fulltext.fulltext == b"Sample fulltext content."
+
+
+def test_dataset_fulltext_date_properties():
+    fulltext = DatasetFulltext(
+        timdex_record_id="alma:123",
+        run_id="test-run-1",
+        run_record_offset=0,
+        fulltext_timestamp="2024-12-01T10:00:00+00:00",
+        fulltext=b"Sample fulltext content.",
+    )
+
+    assert (fulltext.year, fulltext.month, fulltext.day) == ("2024", "12", "01")
+
+
+def test_dataset_fulltext_to_dict():
+    values = {
+        "timdex_record_id": "alma:123",
+        "run_id": "test-run-1",
+        "run_record_offset": 0,
+        "fulltext_timestamp": "2024-12-01T10:00:00+00:00",
+        "fulltext": b"Sample fulltext content.",
+    }
+    fulltext = DatasetFulltext(**values)
+    fulltext_dict = fulltext.to_dict()
+
+    target_md5 = hashlib.md5(
+        b"Sample fulltext content.", usedforsecurity=False
+    ).hexdigest()
+
+    assert fulltext_dict["timdex_record_id"] == "alma:123"
+    assert fulltext_dict["year"] == "2024"
+    assert fulltext_dict["month"] == "12"
+    assert fulltext_dict["day"] == "01"
+    assert fulltext_dict["fulltext"] == b"Sample fulltext content."
+    assert fulltext_dict["fulltext_md5"] == target_md5
+
+
+def test_dataset_fulltext_to_dict_preserves_provided_md5():
+    fulltext = DatasetFulltext(
+        timdex_record_id="alma:123",
+        run_id="test-run-1",
+        run_record_offset=0,
+        fulltext_timestamp="2024-12-01T10:00:00+00:00",
+        fulltext_md5="provided-md5",
+        fulltext=b"Sample fulltext content.",
+    )
+
+    assert fulltext.to_dict()["fulltext_md5"] == "provided-md5"
+
+
+def test_dataset_fulltext_to_dict_no_md5_without_fulltext():
+    fulltext = DatasetFulltext(
+        timdex_record_id="alma:123",
+        run_id="test-run-1",
+        run_record_offset=0,
+        fulltext_timestamp="2024-12-01T10:00:00+00:00",
+    )
+
+    assert fulltext.to_dict()["fulltext_md5"] is None
+
+
+def test_fulltexts_data_root_property(timdex_dataset_empty):
+    timdex_fulltexts = TIMDEXFulltexts(timdex_dataset_empty)
+
+    expected = f"{timdex_dataset_empty.location.removesuffix('/')}/data/fulltexts"
+    assert timdex_fulltexts.data_root == expected
+    assert os.path.exists(expected)
+
+
+def test_fulltexts_write_basic(timdex_dataset_empty, sample_fulltexts_generator):
+    timdex_fulltexts = TIMDEXFulltexts(timdex_dataset_empty)
+    written_files = timdex_fulltexts.write(sample_fulltexts_generator(100))
+
+    assert len(written_files) == 1
+    assert os.path.exists(written_files[0].path)
+
+    # verify written data can be read
+    dataset = ds.dataset(
+        timdex_fulltexts.data_root, format="parquet", partitioning="hive"
+    )
+    assert dataset.count_rows() == 100
+
+
+def test_fulltexts_write_partitioning(timdex_dataset_empty, sample_fulltexts_generator):
+    timdex_fulltexts = TIMDEXFulltexts(timdex_dataset_empty)
+    written_files = timdex_fulltexts.write(sample_fulltexts_generator(10))
+
+    assert len(written_files) == 1
+    assert "year=2024/month=12/day=01" in written_files[0].path
+
+
+def test_fulltexts_write_schema_applied(timdex_dataset_empty, sample_fulltexts_generator):
+    timdex_fulltexts = TIMDEXFulltexts(timdex_dataset_empty)
+    timdex_fulltexts.write(sample_fulltexts_generator(10))
+
+    # manually load dataset to confirm schema
+    dataset = ds.dataset(
+        timdex_fulltexts.data_root,
+        format="parquet",
+        partitioning="hive",
+    )
+
+    assert set(dataset.schema.names) == set(TIMDEXFulltexts.SCHEMA.names)
+
+
+def test_fulltexts_read_batches_yields_pyarrow_record_batches(
+    timdex_dataset_empty, sample_fulltexts_generator, sample_records_generator
+):
+    # write matching records and rebuild metadata
+    timdex_dataset_empty.records.write(
+        sample_records_generator(100, source="alma", run_id="test-run"),
+        write_append_deltas=False,
+    )
+    timdex_dataset_empty.metadata.rebuild_dataset_metadata()
+    timdex_dataset_empty.refresh()
+
+    # write fulltexts
+    timdex_dataset_empty.fulltexts.write(
+        sample_fulltexts_generator(100, run_id="test-run")
+    )
+
+    # rebuild metadata to include fulltexts, then refresh
+    timdex_dataset_empty.metadata.rebuild_dataset_metadata()
+    timdex_dataset_empty.refresh()
+
+    batches = timdex_dataset_empty.fulltexts.read_batches_iter()
+    batch = next(batches)
+    assert isinstance(batch, pa.RecordBatch)
+
+
+def test_fulltexts_read_batches_all_columns_by_default(timdex_fulltexts_with_runs):
+    batches = timdex_fulltexts_with_runs.read_batches_iter()
+    batch = next(batches)
+    assert set(batch.column_names) == FULLTEXTS_AVAILABLE_COLUMNS_SET
+
+
+def test_fulltexts_read_batches_filter_columns(timdex_fulltexts_with_runs):
+    columns_subset = [
+        "timdex_record_id",
+        "run_id",
+        "fulltext_timestamp",
+        "fulltext_md5",
+    ]
+    batches = timdex_fulltexts_with_runs.read_batches_iter(columns=columns_subset)
+    batch = next(batches)
+    assert set(batch.column_names) == set(columns_subset)
+
+
+def test_fulltexts_read_batches_explicit_columns_excludes_metadata(
+    timdex_fulltexts_with_runs,
+):
+    """Explicit column selection excludes metadata columns."""
+    columns_subset = ["timdex_record_id", "fulltext"]
+    batches = timdex_fulltexts_with_runs.read_batches_iter(columns=columns_subset)
+    batch = next(batches)
+    # only requested columns returned, no metadata columns
+    assert set(batch.column_names) == set(columns_subset)
+    assert "source" not in batch.column_names
+    assert "run_date" not in batch.column_names
+
+
+def test_fulltexts_read_batches_mixed_columns(timdex_fulltexts_with_runs):
+    """Select both fulltexts and metadata columns explicitly."""
+    columns = ["timdex_record_id", "source", "fulltext", "run_date"]
+    batches = timdex_fulltexts_with_runs.read_batches_iter(columns=columns)
+    batch = next(batches)
+    assert set(batch.column_names) == set(columns)
+
+
+def test_fulltexts_read_batches_metadata_only_columns(timdex_fulltexts_with_runs):
+    """Select only metadata columns explicitly."""
+    columns = ["source", "run_date", "run_type"]
+    batches = timdex_fulltexts_with_runs.read_batches_iter(columns=columns)
+    batch = next(batches)
+    assert set(batch.column_names) == set(columns)
+
+
+def test_fulltexts_read_batches_invalid_columns_raises_error(
+    timdex_fulltexts_with_runs,
+):
+    """Invalid column names raise ValueError with helpful message."""
+    columns = ["timdex_record_id", "invalid_column", "source"]
+    with pytest.raises(ValueError, match=r"Invalid column.*invalid_column"):
+        list(timdex_fulltexts_with_runs.read_batches_iter(columns=columns))
+
+
+def test_fulltexts_read_batches_gets_full_dataset(timdex_fulltexts_with_runs):
+    batches = timdex_fulltexts_with_runs.read_batches_iter()
+    table = pa.Table.from_batches(batches)
+    dataset = ds.dataset(
+        timdex_fulltexts_with_runs.data_root,
+        format="parquet",
+        partitioning="hive",
+    )
+    assert len(table) == dataset.count_rows()
+
+
+def test_fulltexts_read_batches_with_filters_gets_subset_of_dataset(
+    timdex_fulltexts_with_runs,
+):
+    batches = timdex_fulltexts_with_runs.read_batches_iter(run_id="abc123")
+    table = pa.Table.from_batches(batches)
+    dataset = ds.dataset(
+        timdex_fulltexts_with_runs.data_root,
+        format="parquet",
+        partitioning="hive",
+    )
+    assert len(table) == 100
+    assert len(table) < dataset.count_rows()
+
+
+def test_fulltexts_read_batches_with_metadata_filter_source(
+    timdex_fulltexts_with_runs,
+):
+    """Filter fulltexts by 'source' column from metadata.records via join."""
+    batches = timdex_fulltexts_with_runs.read_batches_iter(source="alma")
+    table = pa.Table.from_batches(batches)
+    assert len(table) == 150
+
+
+def test_fulltexts_read_batches_with_metadata_filter_run_date(
+    timdex_fulltexts_with_runs,
+):
+    """Filter fulltexts by 'run_date' column from metadata.records via join."""
+    batches = timdex_fulltexts_with_runs.read_batches_iter(run_date="2024-12-01")
+    table = pa.Table.from_batches(batches)
+    assert len(table) == 150
+
+
+def test_fulltexts_read_batches_with_combined_filters(
+    timdex_fulltexts_with_runs,
+):
+    """Combine fulltexts filter and metadata filter."""
+    batches = timdex_fulltexts_with_runs.read_batches_iter(source="alma", run_id="abc123")
+    table = pa.Table.from_batches(batches)
+    assert len(table) == 100
+
+
+def test_fulltexts_read_batches_with_fulltext_md5_filter(timdex_fulltexts_with_runs):
+    """Filter fulltexts by generated fulltext_md5 metadata."""
+    expected_md5 = hashlib.md5(
+        b"Sample fulltext content for alma:0.  Content " + (b"x" * 1024),
+        usedforsecurity=False,
+    ).hexdigest()
+
+    batches = timdex_fulltexts_with_runs.read_batches_iter(fulltext_md5=expected_md5)
+    table = pa.Table.from_batches(batches)
+
+    assert len(table) == 2
+    assert set(table.column("timdex_record_id").to_pylist()) == {"alma:0"}
+    assert set(table.column("fulltext_md5").to_pylist()) == {expected_md5}
+
+
+def test_fulltexts_read_dataframes_yields_dataframes(timdex_fulltexts_with_runs):
+    df_iter = timdex_fulltexts_with_runs.read_dataframes_iter()
+    df_batch = next(df_iter)
+    assert isinstance(df_batch, pd.DataFrame)
+    assert len(df_batch) == 150
+
+
+def test_fulltexts_read_dataframe_gets_full_dataset(timdex_fulltexts_with_runs):
+    df = timdex_fulltexts_with_runs.read_dataframe()
+    dataset = ds.dataset(
+        timdex_fulltexts_with_runs.data_root,
+        format="parquet",
+        partitioning="hive",
+    )
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == dataset.count_rows()
+
+
+def test_fulltexts_read_dicts_yields_dictionary_for_each_fulltexts_record(
+    timdex_fulltexts_with_runs,
+):
+    dict_iter = timdex_fulltexts_with_runs.read_dicts_iter()
+    record = next(dict_iter)
+    assert isinstance(record, dict)
+    assert set(record.keys()) == FULLTEXTS_AVAILABLE_COLUMNS_SET
+
+
+def test_current_fulltexts_view_single_run(timdex_dataset_for_fulltexts_views):
+    td = timdex_dataset_for_fulltexts_views
+
+    # write fulltexts for run "apple-1"
+    td.fulltexts.write(generate_sample_fulltexts_for_run(td, run_id="apple-1"))
+
+    # rebuild metadata to include fulltexts, then refresh
+    td.metadata.rebuild_dataset_metadata()
+    td.refresh()
+
+    # query current_fulltexts for apple source using read_dataframe
+    result = td.fulltexts.read_dataframe(table="current_fulltexts", source="apple")
+
+    assert len(result) == 10
+    assert (result["run_id"] == "apple-1").all()
+    assert (result["run_date"] == pd.Timestamp("2025-06-01")).all()
+
+
+def test_current_fulltexts_view_multiple_runs(timdex_dataset_for_fulltexts_views):
+    td = timdex_dataset_for_fulltexts_views
+
+    # write fulltexts for runs "orange-1" and "orange-2"
+    td.fulltexts.write(generate_sample_fulltexts_for_run(td, run_id="orange-1"))
+    td.fulltexts.write(generate_sample_fulltexts_for_run(td, run_id="orange-2"))
+
+    # rebuild metadata to include fulltexts, then refresh
+    td.metadata.rebuild_dataset_metadata()
+    td.refresh()
+
+    # query current_fulltexts for orange source using read_dataframe
+    result = td.fulltexts.read_dataframe(table="current_fulltexts", source="orange")
+
+    # 10 total current fulltexts:
+    # 5 from orange-1 (offsets 5-9), 5 from orange-2 (offsets 0-4)
+    assert len(result) == 10
+
+    # verify 5 from orange-1 (records not in orange-2, run_date 2025-07-01)
+    orange_1_records = result[result["run_id"] == "orange-1"]
+    assert len(orange_1_records) == 5
+    assert (orange_1_records["run_date"] == pd.Timestamp("2025-07-01")).all()
+
+    # verify 5 from orange-2 (newer records, run_date 2025-07-02)
+    orange_2_records = result[result["run_id"] == "orange-2"]
+    assert len(orange_2_records) == 5
+    assert (orange_2_records["run_date"] == pd.Timestamp("2025-07-02")).all()
+
+
+def test_current_fulltexts_prefers_record_recency_over_fulltext_recency(
+    tmp_path,
+):
+    td = TIMDEXDataset(str(tmp_path / "record_recency_wins_dataset/"))
+
+    td.records.write(
+        generate_sample_records(
+            num_records=10,
+            source="pear",
+            run_date="2025-09-01",
+            run_type="full",
+            run_id="pear-1",
+        ),
+        write_append_deltas=False,
+    )
+    td.records.write(
+        generate_sample_records(
+            num_records=5,
+            source="pear",
+            run_date="2025-09-02",
+            run_type="daily",
+            run_id="pear-2",
+        ),
+        write_append_deltas=False,
+    )
+    td.metadata.rebuild_dataset_metadata()
+    td.refresh()
+
+    # older record version gets a later fulltext event
+    td.fulltexts.write(
+        generate_sample_fulltexts_for_run(
+            td,
+            run_id="pear-1",
+            fulltext_timestamp="2025-09-04T00:00:00+00:00",
+        ),
+        write_append_deltas=False,
+    )
+    td.fulltexts.write(
+        generate_sample_fulltexts_for_run(
+            td,
+            run_id="pear-2",
+            fulltext_timestamp="2025-09-03T00:00:00+00:00",
+        ),
+        write_append_deltas=False,
+    )
+    td.metadata.rebuild_dataset_metadata()
+    td.refresh()
+
+    result = td.fulltexts.read_dataframe(table="current_fulltexts", source="pear")
+
+    assert len(result) == 10
+
+    overlap = result[result["timdex_record_id"].isin([f"pear:{i}" for i in range(5)])]
+    non_overlap = result[
+        result["timdex_record_id"].isin([f"pear:{i}" for i in range(5, 10)])
+    ]
+
+    assert (overlap["run_id"] == "pear-2").all()
+    assert (non_overlap["run_id"] == "pear-1").all()
+    assert (
+        overlap["fulltext_timestamp"] == pd.Timestamp("2025-09-03T00:00:00+00:00")
+    ).all()
+
+
+def test_current_fulltexts_excludes_superseded_record_versions(tmp_path):
+    td = TIMDEXDataset(str(tmp_path / "current_fulltexts_current_records_only/"))
+
+    td.records.write(
+        generate_sample_records(
+            num_records=10,
+            source="grape",
+            run_date="2025-09-01",
+            run_type="full",
+            run_id="grape-1",
+        ),
+        write_append_deltas=False,
+    )
+    td.records.write(
+        generate_sample_records(
+            num_records=5,
+            source="grape",
+            run_date="2025-09-02",
+            run_type="daily",
+            run_id="grape-2",
+        ),
+        write_append_deltas=False,
+    )
+    td.metadata.rebuild_dataset_metadata()
+
+    td.fulltexts.write(
+        generate_sample_fulltexts_for_run(td, run_id="grape-1"),
+        write_append_deltas=False,
+    )
+    td.metadata.rebuild_dataset_metadata()
+    td.refresh()
+
+    result = td.fulltexts.read_dataframe(table="current_fulltexts", source="grape")
+
+    assert len(result) == 5
+    assert set(result["timdex_record_id"]) == {f"grape:{i}" for i in range(5, 10)}
+    assert (result["run_id"] == "grape-1").all()
+
+
+def test_current_fulltexts_view_handles_duplicate_run_fulltexts(
+    tmp_path,
+):
+    """Test that duplicate fulltexts for the same run are handled correctly."""
+    td = TIMDEXDataset(str(tmp_path / "dup_run_dataset/"))
+
+    # scenario: lemon - full run + daily run (daily will have fulltexts written twice)
+    td.records.write(
+        generate_sample_records(
+            num_records=10,
+            source="lemon",
+            run_date="2025-08-01",
+            run_type="full",
+            run_id="lemon-1",
+        ),
+        write_append_deltas=False,
+    )
+    td.records.write(
+        generate_sample_records(
+            num_records=5,
+            source="lemon",
+            run_date="2025-08-02",
+            run_type="daily",
+            run_id="lemon-2",
+        ),
+        write_append_deltas=False,
+    )
+    td.metadata.rebuild_dataset_metadata()
+    td = TIMDEXDataset(td.location)
+
+    # write fulltexts for run "lemon-1"
+    td.fulltexts.write(generate_sample_fulltexts_for_run(td, run_id="lemon-1"))
+
+    # first fulltexts write for run "lemon-2"
+    td.fulltexts.write(
+        generate_sample_fulltexts_for_run(
+            td, run_id="lemon-2", fulltext_timestamp="2025-08-02T00:00:00+00:00"
+        )
+    )
+
+    # second fulltexts write for run "lemon-2" with a later timestamp
+    td.fulltexts.write(
+        generate_sample_fulltexts_for_run(
+            td, run_id="lemon-2", fulltext_timestamp="2025-08-03T00:00:00+00:00"
+        )
+    )
+
+    # rebuild metadata to include fulltexts, then refresh
+    td.metadata.rebuild_dataset_metadata()
+    td.refresh()
+
+    # check all fulltexts for lemon-2 to verify both writes exist
+    all_lemon_2 = td.fulltexts.read_dataframe(table="fulltexts", run_id="lemon-2")
+    # should have 10 rows (5 from first write, 5 from second write)
+    assert len(all_lemon_2) == 10
+
+    # verify both timestamps exist
+    unique_timestamps = all_lemon_2["fulltext_timestamp"].unique()
+    assert len(unique_timestamps) == 2
+
+    # query current_fulltexts for lemon source
+    result = td.fulltexts.read_dataframe(table="current_fulltexts", source="lemon")
+
+    # 10 current fulltexts: 5 from lemon-1, 5 from lemon-2 (latest timestamp)
+    assert len(result) == 10
+
+    # verify lemon-1 fulltexts (run_date 2025-08-01)
+    lemon_1_result = result[result["run_id"] == "lemon-1"]
+    assert len(lemon_1_result) == 5
+    assert (lemon_1_result["run_date"] == pd.Timestamp("2025-08-01")).all()
+
+    # verify lemon-2 fulltexts have the later fulltext timestamp (run_date 2025-08-02)
+    lemon_2_result = result[result["run_id"] == "lemon-2"]
+    assert len(lemon_2_result) == 5
+    assert (lemon_2_result["run_date"] == pd.Timestamp("2025-08-02")).all()
+
+    # all lemon-2 current fulltexts should have the later fulltext timestamp
+    max_timestamp = all_lemon_2["fulltext_timestamp"].max()
+    assert (lemon_2_result["fulltext_timestamp"] == max_timestamp).all()
+
+
+def test_fulltexts_view_includes_all_fulltexts(tmp_path):
+    """Test that the fulltexts view includes all fulltexts from multiple writes."""
+    td = TIMDEXDataset(str(tmp_path / "all_fulltexts_dataset/"))
+
+    # scenario: lemon - full run + daily run (daily will have fulltexts written twice)
+    td.records.write(
+        generate_sample_records(
+            num_records=10,
+            source="lemon",
+            run_date="2025-08-01",
+            run_type="full",
+            run_id="lemon-1",
+        ),
+        write_append_deltas=False,
+    )
+    td.records.write(
+        generate_sample_records(
+            num_records=5,
+            source="lemon",
+            run_date="2025-08-02",
+            run_type="daily",
+            run_id="lemon-2",
+        ),
+        write_append_deltas=False,
+    )
+    td.metadata.rebuild_dataset_metadata()
+    td = TIMDEXDataset(td.location)
+
+    # write fulltexts for lemon-1
+    td.fulltexts.write(generate_sample_fulltexts_for_run(td, run_id="lemon-1"))
+
+    # write fulltexts for lemon-2 (first time) with explicit timestamp
+    td.fulltexts.write(
+        generate_sample_fulltexts_for_run(
+            td, run_id="lemon-2", fulltext_timestamp="2025-08-02T00:00:00+00:00"
+        )
+    )
+
+    # write fulltexts for lemon-2 again with later timestamp
+    td.fulltexts.write(
+        generate_sample_fulltexts_for_run(
+            td, run_id="lemon-2", fulltext_timestamp="2025-08-03T00:00:00+00:00"
+        )
+    )
+
+    # rebuild metadata to include fulltexts, then refresh
+    td.metadata.rebuild_dataset_metadata()
+    td.refresh()
+
+    # query all fulltexts for lemon source
+    result = td.fulltexts.read_dataframe(table="fulltexts", source="lemon")
+
+    # 20 total fulltexts: 10 from lemon-1, 5 from lemon-2 first write,
+    # 5 from lemon-2 second write
+    assert len(result) == 20
+
+    # verify run_date distribution
+    lemon_1_fulltexts = result[result["run_id"] == "lemon-1"]
+    assert len(lemon_1_fulltexts) == 10
+    assert (lemon_1_fulltexts["run_date"] == pd.Timestamp("2025-08-01")).all()
+
+    lemon_2_fulltexts = result[result["run_id"] == "lemon-2"]
+    assert len(lemon_2_fulltexts) == 10  # 5 from each write
+    assert (lemon_2_fulltexts["run_date"] == pd.Timestamp("2025-08-02")).all()
+
+
+def test_fulltexts_read_batches_iter_returns_empty_when_fulltexts_missing(
+    timdex_dataset_empty,
+):
+    with pytest.raises(
+        ValueError,
+        match=r"Table 'fulltexts' not found in DuckDB context.*rebuild_dataset_metadata",
+    ):
+        list(timdex_dataset_empty.fulltexts.read_batches_iter())
+
+
+def test_fulltexts_read_batches_iter_returns_empty_for_invalid_table(
+    timdex_fulltexts_with_runs,
+):
+    """read_batches_iter returns empty iterator for nonexistent table name."""
+    with pytest.raises(
+        ValueError,
+        match="Invalid table: 'nonexistent'",
+    ):
+        list(timdex_fulltexts_with_runs.read_batches_iter(table="nonexistent"))

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -10,7 +10,7 @@ from duckdb import DuckDBPyConnection
 from tests.utils import generate_sample_embeddings_for_run, generate_sample_records
 from timdex_dataset_api import TIMDEXDataset
 from timdex_dataset_api.data_type import TIMDEXDataType
-from timdex_dataset_api.data_types import TIMDEXEmbeddings, TIMDEXRecords
+from timdex_dataset_api.data_types import TIMDEXEmbeddings, TIMDEXFulltexts, TIMDEXRecords
 from timdex_dataset_api.metadata import TIMDEXDatasetMetadata
 
 
@@ -57,6 +57,20 @@ def test_data_type_metadata_columns_are_derived_from_base_class():
         "embedding_strategy",
     ] == TIMDEXEmbeddings.METADATA_COLUMNS
 
+    assert TIMDEXFulltexts.DATATYPE_METADATA_COLUMNS == [
+        "timdex_record_id",
+        "run_id",
+        "run_record_offset",
+        "filename",
+        "fulltext_timestamp",
+        "fulltext_md5",
+    ]
+    assert [
+        *TIMDEXDatasetMetadata.BASE_METADATA_COLUMNS,
+        "fulltext_timestamp",
+        "fulltext_md5",
+    ] == TIMDEXFulltexts.METADATA_COLUMNS
+
 
 def test_data_type_subclass_requires_contract_vars():
     with pytest.raises(
@@ -76,8 +90,10 @@ def test_dataset_registers_table_configs_from_data_types(tmp_path):
 
     expected_table_names = [
         table_config.name
-        for table_config in (TIMDEXRecords.TABLES + TIMDEXEmbeddings.TABLES)
+        for data_type_class in td.data_type_classes
+        for table_config in data_type_class.TABLES
     ]
+
     assert [
         table_config.name for table_config in td.table_configs
     ] == expected_table_names

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,8 +7,12 @@ import random
 import uuid
 from collections.abc import Iterator
 
-from timdex_dataset_api import DatasetRecord, TIMDEXDataset
-from timdex_dataset_api.data_types.embeddings import DatasetEmbedding
+from timdex_dataset_api import TIMDEXDataset
+from timdex_dataset_api.data_types import (
+    DatasetEmbedding,
+    DatasetFulltext,
+    DatasetRecord,
+)
 
 
 def generate_sample_records(
@@ -130,4 +134,54 @@ def generate_sample_embeddings_for_run(
             embedding_vector=embedding_vector,
             embedding_object=embedding_object,
             embedding_timestamp=embedding_timestamp,
+        )
+
+
+def generate_sample_fulltexts(
+    num_fulltexts: int,
+    source: str | None = "alma",
+    run_id: str | None = None,
+    fulltext_timestamp: str | None = "2024-12-01T00:00:00+00:00",
+) -> Iterator[DatasetFulltext]:
+    """Generate sample DatasetFulltexts."""
+    if not run_id:
+        run_id = str(uuid.uuid4())
+
+    for x in range(num_fulltexts):
+        yield DatasetFulltext(
+            timdex_record_id=f"{source}:{x}",
+            run_id=run_id,
+            run_record_offset=x,
+            fulltext_timestamp=fulltext_timestamp,
+            fulltext=f"Sample fulltext content for {source}:{x}.".encode(),
+        )
+
+
+def generate_sample_fulltexts_for_run(
+    timdex_dataset: TIMDEXDataset,
+    run_id: str,
+    fulltext_timestamp: str | None = None,
+    fulltext_length: int = 1024,
+) -> Iterator[DatasetFulltext]:
+    """Generate sample DatasetFulltexts for a given ETL run."""
+    records_metadata = timdex_dataset.conn.query(f"""
+    select
+        *
+    from metadata.records
+    where run_id = '{run_id}';
+    """).to_df()
+
+    if not fulltext_timestamp:
+        fulltext_timestamp = records_metadata.iloc[0].run_timestamp.isoformat()
+
+    for _idx, record in records_metadata.iterrows():
+        yield DatasetFulltext(
+            timdex_record_id=record.timdex_record_id,
+            run_id=run_id,
+            run_record_offset=record.run_record_offset,
+            fulltext_timestamp=fulltext_timestamp,
+            fulltext=(
+                f"Sample fulltext content for {record.timdex_record_id}.  "
+                f"Content {'x' * fulltext_length}"
+            ).encode(),
         )

--- a/timdex_dataset_api/__init__.py
+++ b/timdex_dataset_api/__init__.py
@@ -2,22 +2,12 @@
 
 from importlib.metadata import version
 
-from timdex_dataset_api.data_type import DataTypeTableConfig, TIMDEXDataType
-from timdex_dataset_api.data_types import TIMDEXEmbeddings, TIMDEXRecords
-from timdex_dataset_api.data_types.embeddings import DatasetEmbedding
-from timdex_dataset_api.data_types.records import DatasetRecord
 from timdex_dataset_api.dataset import TIMDEXDataset
 from timdex_dataset_api.metadata import TIMDEXDatasetMetadata
 
 __version__ = version("timdex_dataset_api")
 
 __all__ = [
-    "DataTypeTableConfig",
-    "DatasetEmbedding",
-    "DatasetRecord",
-    "TIMDEXDataType",
     "TIMDEXDataset",
     "TIMDEXDatasetMetadata",
-    "TIMDEXEmbeddings",
-    "TIMDEXRecords",
 ]

--- a/timdex_dataset_api/__init__.py
+++ b/timdex_dataset_api/__init__.py
@@ -2,12 +2,29 @@
 
 from importlib.metadata import version
 
+from timdex_dataset_api.data_types import (
+    DatasetEmbedding,
+    DatasetFulltext,
+    DatasetRecord,
+    TIMDEXEmbeddings,
+    TIMDEXFulltexts,
+    TIMDEXRecords,
+)
 from timdex_dataset_api.dataset import TIMDEXDataset
 from timdex_dataset_api.metadata import TIMDEXDatasetMetadata
 
 __version__ = version("timdex_dataset_api")
 
+# NOTE: proposed that we remove all imports from 'data_types' on next major release
+#   to avoid over-populating the root namespace.   Leaving now for backwards
+#   compatibility.
 __all__ = [
+    "DatasetEmbedding",
+    "DatasetFulltext",
+    "DatasetRecord",
     "TIMDEXDataset",
     "TIMDEXDatasetMetadata",
+    "TIMDEXEmbeddings",
+    "TIMDEXFulltexts",
+    "TIMDEXRecords",
 ]

--- a/timdex_dataset_api/data_types/__init__.py
+++ b/timdex_dataset_api/data_types/__init__.py
@@ -1,6 +1,7 @@
 """TIMDEX dataset data type implementations."""
 
 from timdex_dataset_api.data_types.embeddings import DatasetEmbedding, TIMDEXEmbeddings
+from timdex_dataset_api.data_types.fulltexts import DatasetFulltext, TIMDEXFulltexts
 from timdex_dataset_api.data_types.records import (
     DatasetRecord,
     RecordsFilters,
@@ -9,8 +10,10 @@ from timdex_dataset_api.data_types.records import (
 
 __all__ = [
     "DatasetEmbedding",
+    "DatasetFulltext",
     "DatasetRecord",
     "RecordsFilters",
     "TIMDEXEmbeddings",
+    "TIMDEXFulltexts",
     "TIMDEXRecords",
 ]

--- a/timdex_dataset_api/data_types/fulltexts.py
+++ b/timdex_dataset_api/data_types/fulltexts.py
@@ -1,0 +1,190 @@
+import hashlib
+from datetime import UTC, datetime
+from typing import ClassVar
+
+import attrs
+import pyarrow as pa
+from attrs import asdict, define, field
+
+from timdex_dataset_api.data_type import DataTypeTableConfig, TIMDEXDataType
+from timdex_dataset_api.utils import datetime_iso_parse
+
+
+@define
+class DatasetFulltext:
+    """Container for single record fulltext.
+
+    Fields:
+        timdex_record_id: Fields (timdex_record_id, run_id, run_record_offset) combine to
+            form a composite key that points to a single, distinct record version in the
+            records data.
+        run_id: ...
+        run_record_offset: ...
+        fulltext_timestamp: Timestamp when fulltext was extracted / added to TIMDEX
+            dataset
+        fulltext_md5: MD5 checksum for the fulltext payload. If omitted, generated
+            from fulltext when serializing.
+        fulltext: Fulltext for the record.
+    """
+
+    timdex_record_id: str = field()
+    run_id: str = field()
+    run_record_offset: int = field()
+
+    fulltext_timestamp: datetime = field(  # type: ignore[assignment]
+        converter=datetime_iso_parse,
+        default=attrs.Factory(lambda: datetime.now(tz=UTC).isoformat()),
+    )
+    fulltext_md5: str | None = field(default=None)
+    fulltext: bytes | None = field(default=None)
+
+    @property
+    def year(self) -> str:
+        return self.fulltext_timestamp.strftime("%Y")
+
+    @property
+    def month(self) -> str:
+        return self.fulltext_timestamp.strftime("%m")
+
+    @property
+    def day(self) -> str:
+        return self.fulltext_timestamp.strftime("%d")
+
+    def to_dict(
+        self,
+    ) -> dict:
+        """Serialize instance as dictionary."""
+        return {
+            **asdict(self),
+            "fulltext_md5": self._fulltext_md5(),
+            "year": self.year,
+            "month": self.month,
+            "day": self.day,
+        }
+
+    def _fulltext_md5(self) -> str | None:
+        """Calculate an MD5 hash on the fulltext bytes if not explicitly set already."""
+        if self.fulltext_md5:
+            return self.fulltext_md5
+        if self.fulltext is None:
+            return None
+        return hashlib.md5(self.fulltext, usedforsecurity=False).hexdigest()
+
+
+class TIMDEXFulltexts(TIMDEXDataType):
+    """Class to handle record fulltexts in the TIMDEXDataset."""
+
+    NAME: ClassVar[str] = "fulltexts"
+
+    SCHEMA: ClassVar[pa.Schema] = pa.schema(
+        (
+            pa.field("timdex_record_id", pa.string()),
+            pa.field("run_id", pa.string()),
+            pa.field("run_record_offset", pa.int32()),
+            pa.field("fulltext_timestamp", pa.timestamp("us", tz="UTC")),
+            pa.field("fulltext_md5", pa.string()),
+            pa.field("fulltext", pa.binary()),
+            pa.field("year", pa.string()),
+            pa.field("month", pa.string()),
+            pa.field("day", pa.string()),
+        )
+    )
+
+    DATA_COLUMNS: ClassVar[list[str]] = ["fulltext"]
+
+    DATA_PATH: ClassVar[str] = "data/fulltexts"
+
+    CURRENT_METADATA_VIEW_QUERY: ClassVar[str] = """
+        with
+            -- CTE of fulltexts attached to current record versions only
+            cf_current_record_fulltexts as
+            (
+                select
+                    f.*
+                from metadata.fulltexts f
+                join metadata.current_records r using (
+                    source,
+                    timdex_record_id,
+                    run_id,
+                    run_record_offset
+                )
+            ),
+
+            -- CTE of current-record fulltexts ranked by fulltext recency
+            cf_ranked_fulltexts as
+            (
+                select
+                    f.*,
+                    row_number() over (
+                        partition by
+                            f.timdex_record_id
+                        order by
+                            f.fulltext_timestamp desc nulls last,
+                            f.filename desc nulls last
+                    ) as rn
+                from cf_current_record_fulltexts f
+            )
+        -- final select for current fulltexts (rn = 1)
+        select
+            * exclude (rn)
+        from cf_ranked_fulltexts
+        where rn = 1
+    """
+
+    CURRENT_RUN_METADATA_VIEW_QUERY: ClassVar[str] = """
+        with
+            -- CTE of fulltexts ranked by fulltext recency within a run
+            -- keep run_timestamp because the same run_id can be written more than once
+            -- keep run_record_offset as an intra-run tie-break when the same logical
+            -- record appears more than once within a run
+            crcf_ranked_fulltexts as
+            (
+                select
+                    f.*,
+                    row_number() over (
+                        partition by
+                            f.timdex_record_id,
+                            f.run_id
+                        order by
+                            f.run_timestamp desc nulls last,
+                            f.fulltext_timestamp desc nulls last,
+                            f.run_record_offset desc nulls last,
+                            f.filename desc nulls last
+                    ) as rn
+                from metadata.fulltexts f
+            )
+        -- final select for current run fulltexts (rn = 1)
+        select
+            * exclude (rn)
+        from crcf_ranked_fulltexts
+        where rn = 1
+    """
+
+    TABLES: ClassVar[list[DataTypeTableConfig]] = [
+        DataTypeTableConfig(
+            name="fulltexts",
+            description="All fulltext versions across all runs.",
+            kind="base",
+        ),
+        DataTypeTableConfig(
+            name="current_fulltexts",
+            description=(
+                "One row per timdex_record_id representing the most recent fulltext "
+                "for each current record."
+            ),
+            kind="custom",
+            query_sql=CURRENT_METADATA_VIEW_QUERY,
+            required_metadata_tables=["fulltexts", "current_records"],
+        ),
+        DataTypeTableConfig(
+            name="current_run_fulltexts",
+            description=(
+                "One row per (timdex_record_id, run_id) representing the most "
+                "recent fulltext within each run, regardless of whether the "
+                "record is current."
+            ),
+            kind="custom",
+            query_sql=CURRENT_RUN_METADATA_VIEW_QUERY,
+            required_metadata_tables=["fulltexts", "records"],
+        ),
+    ]

--- a/timdex_dataset_api/dataset.py
+++ b/timdex_dataset_api/dataset.py
@@ -12,7 +12,11 @@ from pyarrow import fs
 from sqlalchemy import MetaData, Table, create_engine
 
 from timdex_dataset_api.config import configure_logger
-from timdex_dataset_api.data_types import TIMDEXEmbeddings, TIMDEXRecords
+from timdex_dataset_api.data_types import (
+    TIMDEXEmbeddings,
+    TIMDEXFulltexts,
+    TIMDEXRecords,
+)
 from timdex_dataset_api.metadata import TIMDEXDatasetMetadata
 from timdex_dataset_api.utils import DuckDBConnectionFactory
 
@@ -91,7 +95,7 @@ class TIMDEXDataset:
         # create schemas
         self._create_duckdb_schemas()
 
-        self.data_type_classes = [TIMDEXRecords, TIMDEXEmbeddings]
+        self.data_type_classes = [TIMDEXRecords, TIMDEXEmbeddings, TIMDEXFulltexts]
 
         # define readable metadata-backed tables contributed by data types
         self.table_configs = [
@@ -101,9 +105,10 @@ class TIMDEXDataset:
         ]
 
         # composed components receive self
-        self.records = TIMDEXRecords(self)
         self.metadata = TIMDEXDatasetMetadata(self)
+        self.records = TIMDEXRecords(self)
         self.embeddings = TIMDEXEmbeddings(self)
+        self.fulltexts = TIMDEXFulltexts(self)
 
         # SQLAlchemy (SA) reflection after components have set up their views
         self.sa_tables: dict[str, dict[str, Table]] = {}

--- a/uv.lock
+++ b/uv.lock
@@ -1612,7 +1612,7 @@ wheels = [
 
 [[package]]
 name = "timdex-dataset-api"
-version = "5.0.1"
+version = "5.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
### Purpose and background context

This PR adds a new "fulltexts" data type to the TIMDEX dataset, sitting along pre-existing data types "records" and "embeddings".

This data type add leverages the new data type parity, requiring basically just a schema + metadata definition, relying on shared code for all data types.

This "fulltext" rows capture fulltext associated with a TIMDEX record.  At this time, only DSpace theses will have fulltext records, but we may explore including LibGuides and MITLib websites fulltext in here as well (currently they are added directly to the Opensearch document by Transmogrifier, making them searchable, but not available in the dataset for any additional uses).  We may also explore fulltext for other sources, e.g. archival materials, Dome materials, etc.

Unlike embeddings, there is not much metadata about fulltexts at this time.  We do include an MD5 checksum of the fulltext bytes to avoid re-harvesting / re-writing fulltext in the future, but that is not currently utilized (though CLI app dspace-fulltext-harvester may use it).  The primary data column is simply `fulltext` with the fulltext of the record as bytes.

The first planned use of this new data type is this:
1. For source `dspace`, run the dspace-fulltext-harvester as part of the TIMDEX ETL StepFunction
2. Write data back to this new data type
3. Update TIM to update Opensearch records with fulltext stored here, very similar to how we did embeddings

### How can a reviewer manually see the effects of these changes?

1- Set Dev `TimdexManagers` Credentials

2- Set env vars:
```shell
TDA_LOG_LEVEL=DEBUG
WARNING_ONLY_LOGGERS=asyncio,botocore,urllib3,s3transfer,boto3,MARKDOWN
TIMDEX_DATASET_LOCATION=s3://timdex-extract-dev-222053980223/dataset
```

3- Load dataset:
```python
import os

from timdex_dataset_api import TIMDEXDataset
from timdex_dataset_api.config import configure_dev_logger

configure_dev_logger()

td = TIMDEXDataset(os.environ["TIMDEX_DATASET_LOCATION"])
```

4- Write batch of `fulltexts` records, using an arbitrary `researchdatabases` ETL run as the source TIMDEX  records:
```python
from tests.utils import generate_sample_fulltexts_for_run

# utility to generate some fulltexts
fulltexts = generate_sample_fulltexts_for_run(
    timdex_dataset=td,
    run_id="18cbec87-ce25-4355-a526-caaa3eb1ac1e",  # run for 'researchdatabases'
)

# write to dataset, using recently normalized 'td.<source>.write(...)'
td.fulltexts.write(fulltexts)
# INFO:timdex_dataset_api.data_type:Dataset write complete - elapsed: 12.0s, total files: 1, total rows: 901, total size: 101180
```

5- Confirm our write worked and we can see records:
```python
# get all fulltexts for 'researchdatabases' source
td.fulltexts.read_dataframe(table='current_fulltexts')

# get a single 'fulltexts' record (where the 'xxxxx...' is just filler text)
next(td.fulltexts.read_dicts_iter(table='current_fulltexts'))
"""
Out[12]: 
{'timdex_record_id': 'researchdatabases:az-65257807',
 'source': 'researchdatabases',
 'run_date': datetime.datetime(2026, 5, 1, 0, 0),
 'run_type': 'full',
 'action': 'index',
 'run_id': '18cbec87-ce25-4355-a526-caaa3eb1ac1e',
 'run_record_offset': 0,
 'run_timestamp': datetime.datetime(2026, 5, 1, 15, 24, 31, 248765, tzinfo=<DstTzInfo 'America/Detroit' EDT-1 day, 20:00:00 DST>),
 'filename': 's3://timdex-extract-dev-222053980223/dataset/data/fulltexts/year=2026/month=05/day=01/ab02e407-b62d-4807-8f3b-7dd1c3a4d6ad-0.parquet',
 'fulltext_timestamp': datetime.datetime(2026, 5, 1, 15, 24, 31, 248765, tzinfo=<DstTzInfo 'America/Detroit' EDT-1 day, 20:00:00 DST>),
 'fulltext_md5': '48dac3804fbe73d3aeb1e272e0460045',
 'fulltext': b'Sample fulltext content for researchdatabases:az-65257807.  Content xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'}
"""
```

Note that the record returned, and as we'll see below in step 6, contain additional metadata about the TIMDEX record like `[source, run_date, action, ...]` etc.  This is a byproduct of the v5 refactoring, making all data types in the dataset see very similar "base" metadata for each row, specifically the record it's associated with.


6- Confirm the `fulltext_md5` is a queryable / filterable **metadata** field, not a **data** field:
```python
td.conn.query("""select * from metadata.fulltexts where fulltext_md5 = '967d0a0bf60829bee5dfc05476cc0f0f';""")
# NOTE: there may be multiple rows for this MD5 checksum, given multiple writes
```


### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/USE-531

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.