### PR TITLE
TIMX 646 - avoid virtual filename column reaning in read_parquet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "timdex_dataset_api"
-version = "5.1.0"
+version = "5.2.0"
 description = "Python library for interacting with a TIMDEX parquet dataset"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -262,7 +262,6 @@ def test_tdm_append_deltas_view_empty_structure(timdex_metadata):
         "run_record_offset",
         "run_timestamp",
         "filename",
-        "append_delta_filename",
     }
     assert set(append_deltas_df.columns) == expected_columns
     assert len(append_deltas_df) == 0
@@ -321,6 +320,30 @@ def test_tdm_views_with_append_deltas(timdex_metadata_with_deltas):
 def test_tdm_append_deltas_view_has_data(timdex_metadata_with_deltas):
     append_deltas_count = timdex_metadata_with_deltas.append_deltas_count
     assert append_deltas_count > 0
+
+
+def test_tdm_filename_filter_matches_append_delta_rows(timdex_metadata_with_deltas):
+    conn = timdex_metadata_with_deltas.timdex_dataset.conn
+    filename = conn.execute(
+        "select filename from metadata.records_append_deltas limit 1"
+    ).fetchone()[0]
+
+    delta_count = conn.execute(
+        "select count(*) from metadata.records_append_deltas where filename = ?",
+        [filename],
+    ).fetchone()[0]
+    records_count = conn.execute(
+        "select count(*) from metadata.records where filename = ?", [filename]
+    ).fetchone()[0]
+    shadow_count = conn.execute("""
+        select count(*)
+        from metadata.records_append_deltas
+        where filename like '%append_delta%'
+        """).fetchone()[0]
+
+    assert delta_count > 0
+    assert records_count >= delta_count
+    assert shadow_count == 0
 
 
 def test_tdm_records_includes_deltas(timdex_metadata_with_deltas):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -289,6 +289,10 @@ def test_tdm_append_deltas_count_property_empty(timdex_metadata):
     assert timdex_metadata.append_deltas_count == 0
 
 
+def test_tdm_append_deltas_count_for_missing_view(timdex_metadata_empty):
+    assert timdex_metadata_empty.append_deltas_count_for(TIMDEXRecords) == 0
+
+
 def test_tdm_records_equals_static_without_deltas(timdex_metadata):
     static_count = timdex_metadata.timdex_dataset.conn.query(
         """select count(*) from static_db.records;"""
@@ -455,6 +459,12 @@ def test_tdm_merge_append_deltas_deletes_append_deltas(
 
     assert timdex_metadata_merged_deltas.append_deltas_count == 0
     assert not os.listdir(records_deltas_path_after)
+
+
+def test_tdm_append_deltas_count_for_after_merge(timdex_metadata_with_deltas):
+    timdex_metadata_with_deltas.merge_append_deltas()
+
+    assert timdex_metadata_with_deltas.append_deltas_count_for(TIMDEXRecords) == 0
 
 
 def test_tdm_embeddings_metadata_view_structure(tmp_path):

--- a/timdex_dataset_api/metadata.py
+++ b/timdex_dataset_api/metadata.py
@@ -129,9 +129,12 @@ class TIMDEXDatasetMetadata:
     def append_deltas_count_for(self, data_type_class: type["TIMDEXDataType"]) -> int:
         """Count append deltas rows for a single data type."""
         view_name = f"{data_type_class.NAME}_append_deltas"
-        return self.timdex_dataset.conn.query(f"""
-            select count(*) from metadata.{view_name};
-        """).fetchone()[0]  # type: ignore[index]
+        try:
+            return self.timdex_dataset.conn.query(f"""
+                select count(*) from metadata.{view_name};
+            """).fetchone()[0]  # type: ignore[index]
+        except (DuckDBCatalogException, DuckDBIOException):
+            return 0
 
     @property
     def append_deltas_count(self) -> int:

--- a/timdex_dataset_api/metadata.py
+++ b/timdex_dataset_api/metadata.py
@@ -347,10 +347,7 @@ class TIMDEXDatasetMetadata:
             conn.execute(f"""
                 create or replace view metadata.{view_name} as (
                     select *
-                    from read_parquet(
-                        '{deltas_path}/*.parquet',
-                        filename = 'append_delta_filename'
-                    )
+                    from read_parquet('{deltas_path}/*.parquet')
                 );
             """)
             return
@@ -365,8 +362,7 @@ class TIMDEXDatasetMetadata:
         if table_exists:
             conn.execute(f"""
                 create or replace view metadata.{view_name} as (
-                    select *,
-                        null::varchar as append_delta_filename
+                    select *
                     from {static_table}
                     where 1 = 0
                 );
@@ -578,22 +574,16 @@ class TIMDEXDatasetMetadata:
         all_delta_filenames: dict[str, list[str]] = {}
         has_any_deltas = False
         for data_type_class in self.data_type_classes:
-            deltas_view = f"{data_type_class.NAME}_append_deltas"
+            deltas_glob = f"{self.append_deltas_path_for(data_type_class)}/*.parquet"
             try:
                 filenames = (
                     self.timdex_dataset.conn.query(f"""
-                        select distinct(append_delta_filename)
-                        from metadata.{deltas_view}
+                        select file from glob('{deltas_glob}')
                     """)
-                    .to_df()["append_delta_filename"]
+                    .to_df()["file"]
                     .to_list()
                 )
-            except (
-                DuckDBIOException,
-                DuckDBCatalogException,
-                DuckDBBinderException,
-                KeyError,
-            ):
+            except (DuckDBIOException, KeyError):
                 filenames = []
             all_delta_filenames[data_type_class.NAME] = filenames
             if filenames:

--- a/uv.lock
+++ b/uv.lock
@@ -1612,7 +1612,7 @@ wheels = [
 
 [[package]]
 name = "timdex-dataset-api"
-version = "5.1.0"
+version = "5.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
### Purpose and background context

Please see ticket for background: https://mitlibraries.atlassian.net/browse/TIMX-646.

In summary:
- a new application was performing a `where filename = ...` clause that had not been done before because it was not needed for day-to-day ETL usage of TDA
- it reveals a potential bug in DuckDB where the virtual column `filename` when reading parquet files is potentially treated differently for selecting vs filtering against

This PR updates TDA to stop renaming the virtual `filename` column when reading append deltas for data types (records, embeddings, fulltexts) to avoid subtle bugs in downstream applications.  Instead, we use a simple `glob()` approach, which we were doing already in other contexts.

As noted in the Jira ticket, a DuckDB issue has been created.  This may or may not result in a change in DuckDB, but either way we need to address it in the short-term.

The effect of these changes in TDA are minimal to none. These changes are mostly for downstream applications that may want to filter on the `metadata.records` table by the parquet filepaths; the column `filename` should be predictably for the data parquet files, not append deltas.

### How can a reviewer manually see the effects of these changes?

#### Observe the bug in DuckDB

1- Ensure you are on DuckDB 1.5.2 or higher

2- Open a DuckDB shell
```
duckdb
```

3- Create a couple of parquet files:
```sql
COPY (
    select
        'foo' as name,
        42 as number,
        '/path/to/a/related/thing1' as filename
)
TO '/tmp/duckdb-fake-data-1.parquet';

COPY (
    select
        'bar' as name,
        101 as number,
        '/path/to/a/related/thing2' as filename
)
TO '/tmp/duckdb-fake-data-2.parquet';
```

4- Create a view that projects over these, renaming the virtual `filename` column:
```sql
create view deltas as
select *
from read_parquet(
    '/tmp/duckdb-fake-data-*.parquet',
    filename = 'append_delta_filename'
);
```

5- Note that a `select` statement treats these columns correctly:
```
select filename, append_delta_filename
from deltas;
/*
┌─────────┬───────────────────────────┬─────────────────────────────────┐
│  name   │         filename          │      append_delta_filename      │
│ varchar │          varchar          │             varchar             │
├─────────┼───────────────────────────┼─────────────────────────────────┤
│ foo     │ /path/to/a/related/thing1 │ /tmp/duckdb-fake-data-1.parquet │
│ bar     │ /path/to/a/related/thing2 │ /tmp/duckdb-fake-data-2.parquet │
└─────────┴───────────────────────────┴─────────────────────────────────┘
*/
```

The `filename` column is the "real" data from the parquet file, and the virtual/dynamic `append_delta_filename` column is the filepath of the parquet files we're reading from using `read_parquet()`.  At this point, all is working as expected.

6- Apply a filter to the `filename` column:
```sql
select name
from deltas
where filename = '/path/to/a/related/thing1';

/*
┌─────────┐
│  name   │
│ varchar │
└─────────┘
  0 rows 
*/
```

Given the results from our `select` statement above, we should have expected to find the "foo" record.  What happened instead was DuckDB applied a `File Filter`, ignoring our renamed virtual column, and actually filters on what we intended to be the `append_delta_filename` column _not_ the `filename` column in the view:

```sql
explain select name
from deltas
where filename = '/path/to/a/related/thing1';

/*
┌─────────────────────────────┐
│┌───────────────────────────┐│
││       Physical Plan       ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│        READ_PARQUET       │
│    ────────────────────   │
│         Function:         │
│        READ_PARQUET       │
│                           │
│     Projections: name     │
│                           │
│       File Filters:       │   <-----------------
│  (filename = '/path/to/a  │
│     /related/thing1')     │
│                           │
│    Scanning Files: 0/2    │
│                           │
│          ~0 rows          │
└───────────────────────────┘
*/
```

#### Confirm that new `glob()` approach works in TDA

1- Start ipython shell and load a local, temp dataset:
```python
from timdex_dataset_api import TIMDEXDataset
from timdex_dataset_api.config import configure_dev_logger

configure_dev_logger()

td = TIMDEXDataset("/tmp/tda-timx-646")
```

2- Write some records, build metadatda, and write some more.  This will result in some append deltas:
```python
from tests.utils import generate_sample_records

# write first records
records = generate_sample_records(10)
td.records.write(records)

# rebuild
td.metadata.rebuild_dataset_metadata()

# write more records
records = generate_sample_records(10)
td.records.write(records)

# refresh
td.refresh()
```

3- Count append deltas:
```python
from timdex_dataset_api import TIMDEXRecords

td.metadata.append_deltas_count_for(TIMDEXRecords)
```

4- Merge append deltas:
```python
td.metadata.merge_append_deltas()
```

5- Count again, should be zero:
```python
td.metadata.append_deltas_count_for(TIMDEXRecords)
```

This demonstrates that counting + merging of append delta remains the same after these changes.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: `append_delta_filename` is no longer a column in the `metadata.<data_type>` views

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-646

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.